### PR TITLE
Create the web search results page

### DIFF
--- a/policytool/web/api.py
+++ b/policytool/web/api.py
@@ -11,12 +11,13 @@ import os.path
 from urllib.parse import urlparse
 
 import falcon
-import jinja2
 from elasticsearch import Elasticsearch
 
+from .templates import TemplateResource
 from . import search
 
 TEMPLATE_ROOT = os.path.join(os.path.dirname(__file__), 'templates')
+
 
 def configure_logger(logger):
     """ Configures our logger w/same settings & handler as our webserver
@@ -32,81 +33,12 @@ logger = logging.getLogger()
 configure_logger(logger)
 
 
-def to_template_names(path):
-    """
-    Maps HTTP request paths to Jinja template paths.
-
-    Args:
-        path: path portion of HTTP GET request
-
-    Returns:
-        Tuple of file paths that Jinja should search for.
-    """
-
-    if not path.startswith('/'):
-        raise ValueError
-    path = path[1:]  # remove leading /, jinja won't want it
-
-    if os.path.basename(path).startswith('_'):
-        # Macros are kept in templates starting with _; don't allow
-        # access to them.
-        return tuple()
-
-    if path == '':
-        return ('index.html',)
-
-    if path.endswith('/'):
-        return (
-            path[:-1] + '.html',
-            os.path.join(path, 'index.html'),
-        )
-
-    if path.endswith('.html'):
-        return (
-            path,
-            os.path.join(path[:-5], 'index.html'),
-        )
-
-    return (
-        path + '.html',
-        os.path.join(path, 'index.html'),
-    )
-
-
 def get_context(os_environ):
     return {
         'POLICYTOOL_VERSION': os_environ.get(
             'POLICYTOOL_VERSION', 'development'
         )
     }
-
-
-class TemplateResource:
-    """
-    Serves HTML templates. Note that templates are read from the FS for
-    every request.
-    """
-
-    def __init__(self, template_dir, context=None):
-        logger.info('TemplateResource: template_dir=%s', template_dir)
-        self.env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(template_dir),
-            autoescape=jinja2.select_autoescape(['html']),
-        )
-        if context is not None:
-            self.context = context
-        else:
-            self.context = {}
-
-    def on_get(self, req, resp):
-        tnames = to_template_names(req.path)
-        try:
-            template = self.env.select_template(tnames)
-            resp.body = template.render(**self.context)
-            resp.content_type = 'text/html'
-        except jinja2.TemplateNotFound:
-            resp.status = falcon.HTTP_404
-            return
 
 
 def create_api(conf):
@@ -135,12 +67,21 @@ def create_api(conf):
         TemplateResource(TEMPLATE_ROOT, get_context(os.environ))
     )
     api.add_route(
-        '/search',
+        '/search/citations',
         TemplateResource(TEMPLATE_ROOT, get_context(os.environ))
     )
     api.add_route(
+        '/search/content',
+        TemplateResource(TEMPLATE_ROOT, get_context(os.environ))
+    )
+    api.add_route(
+        '/results/content',
+        search.FulltextPage(TEMPLATE_ROOT, es, conf.es_explain,
+                            get_context(os.environ))
+    )
+    api.add_route(
         '/api/search',
-        search.Fulltext(es, conf.es_explain)
+        search.FulltextApi(es, conf.es_explain)
     )
     api.add_static_route('/static', conf.static_root)
     return api

--- a/policytool/web/gulpfile.js
+++ b/policytool/web/gulpfile.js
@@ -1,4 +1,4 @@
-const { 
+const {
   dest,
   parallel,
   src,
@@ -24,7 +24,7 @@ exports.css = function() {
     .pipe( postcss(plugins) )
     // sourcemaps are rooted in dest(), so '.' is what we want
     .pipe( sourcemaps.write('.') )
-    .pipe( dest('/build/web/static') );
+    .pipe( dest('/src/build/static') );
 };
 
 exports.default = parallel(exports.css);

--- a/policytool/web/search.py
+++ b/policytool/web/search.py
@@ -1,28 +1,45 @@
 import json
+import math
 
 from elasticsearch import ConnectionError, NotFoundError
 import falcon
 
 from . import api
+from .templates import TemplateResource
 
 
-class Fulltext:
-    """Let you search for terms in publications fulltexts.
+def _get_pages(current_page, last_page):
+    """Return a list of pages to be used in the rendered template from the
+    last page number."""
+    pages = []
 
-    Args:
-        es: An elasticsearch connection
-    """
+    if current_page > 3:
+        pages.append(1)
 
-    def __init__(self, es, es_explain):
-        self.es = es
-        self.es_explain = es_explain
+    if current_page > 4:
+        pages.append('...')
+    pages.extend(
+        range(
+            max(current_page - 2, 1), min(current_page + 3, last_page)
+        )
+    )
+    if current_page < last_page - 3:
+        pages.append('...')
 
-    def _search_es(self, req_params):
+    if last_page not in pages:
+        pages.append(last_page)
+
+    return pages
+
+
+def _search_es(es, params, explain=False):
         """Run a search on the elasticsearch database.
 
         Args:
-            req_params: The request's parameters. Shoud include 'term' and at
-                        least a field (on of [text|title|organisation])
+            es: An Elasticsearch active connection.
+            params: The request's parameters. Shoud include 'term' and at
+                    least a field ([text|title|organisation]).
+            explain: A boolean to enable|disable elasticsearch's explain.
 
         Returns:
             True|False: The search success status
@@ -30,14 +47,19 @@ class Fulltext:
                              succeeded or a string explaining why it failed
         """
         try:
-            fields = req_params.get('fields', [])
-            self.es.cluster.health(wait_for_status='yellow')
+            fields = params.get('fields', [])
+            page = params.get('page', 1)
+            size = params.get('size', 50)
+            es.cluster.health(wait_for_status='yellow')
 
             es_body = {
+                'from': (page - 1) * size,
+                'size': size,
                 'query': {
                     'multi_match': {
-                        'query': req_params.get('term'),
-                        'fields': fields
+                        'query': params.get('term'),
+                        'type': "best_fields",
+                        'fields': ['.'.join(['doc', f]) for f in fields]
                     }
                 }
             }
@@ -46,10 +68,10 @@ class Fulltext:
                 query=es_body
             ))
 
-            return True, self.es.search(
-                index='datalabs-fulltexts',
+            return True, es.search(
+                index='policy-test-docs',
                 body=json.dumps(es_body),
-                explain=self.es_explain
+                explain=explain
             )
 
         except ConnectionError:
@@ -65,6 +87,20 @@ class Fulltext:
             api.logger.error(e)
             raise falcon.HTTPError(description=str(e))
 
+
+class FulltextApi:
+    """Let you search for terms in publications fulltexts. Returns a json.
+
+    Args:
+        es: An elasticsearch connection
+        es_explain: A boolean to enable|disable elasticsearch's explain.
+
+    """
+
+    def __init__(self, es, es_explain):
+        self.es = es
+        self.es_explain = es_explain
+
     def on_get(self, req, resp):
         """Returns the result of a search on the elasticsearch cluster.
 
@@ -73,7 +109,7 @@ class Fulltext:
             resp: The reponse object to be returned
         """
         if req.params:
-            status, response = self._search_es(req.params)
+            status, response = _search_es(self.es, req.params, self.es_explain)
             if status:
                 response['status'] = 'success'
                 resp.body = json.dumps(response)
@@ -88,3 +124,41 @@ class Fulltext:
                 'message': "The request doesn't contain any parameters"
             })
             resp.status = falcon.HTTP_400
+
+
+class FulltextPage(TemplateResource):
+    """Let you search for terms in publications fulltexts. Returns a web page.
+
+    Args:
+        es: An elasticsearch connection
+        es_explain: A boolean to enable|disable elasticsearch's explain.
+
+    """
+
+    def __init__(self, template_dir, es, es_explain, context=None):
+        self.es = es
+        self.es_explain = es_explain
+
+        super(FulltextPage, self).__init__(template_dir, context)
+
+    def on_get(self, req, resp):
+        if req.params:
+            params = {
+                "term": req.params['term'],
+                "fields": ["text", "organisation"],
+                "page": int(req.params.get('page', 1)),
+                "size": int(req.params.get('size', 50)),
+            }
+
+            status, response = _search_es(self.es, params, True)
+
+            self.context['es_response'] = response
+            self.context['es_status'] = status
+            self.context['pages'] = _get_pages(
+                params['page'],
+                math.ceil(
+                    float(response['hits']['total']['value']) / params['size'])
+                )
+
+            self.context.update(params)
+        super(FulltextPage, self).on_get(req, resp)

--- a/policytool/web/static/results.css
+++ b/policytool/web/static/results.css
@@ -1,0 +1,22 @@
+@import "variables.css";
+
+.results-box {
+    background: $footerColor;
+    border-top: 1px solid $borderDark;
+    border-bottom: 1px solid $borderDark;
+    padding: $sectionPadding 0;
+}
+
+.results {
+	/*background: #FFF;*/
+}
+
+.table-bordered {
+	tr {
+		background: #FFF;
+	}
+
+	td, th {
+		border: 1px solid $borderDark;
+	}
+}

--- a/policytool/web/static/search.css
+++ b/policytool/web/static/search.css
@@ -1,11 +1,5 @@
 @import "variables.css";
 
-
-/* Override Spectre default */
-.breadcrumb .breadcrumb-item:not(:last-child) a {
-    color: $linkBlue;
-}
-
 .search-box {
     background: $footerColor;
     border-top: 1px solid $borderDark;

--- a/policytool/web/static/style.css
+++ b/policytool/web/static/style.css
@@ -9,6 +9,7 @@ $spectre_version: 0.5.8;
  */
 
 @import "search.css";
+@import "results.css";
 
 
 
@@ -39,6 +40,7 @@ body {
 a, a:visited {
   text-decoration: underline;
   color: $linkBlue;
+  cursor: pointer;
 }
 
  a:hover {
@@ -69,8 +71,27 @@ h3 {
     }
 }
 
+/* btn-lg is still a bit too small for us, make btn-xl from spectre class */
+.btn.btn-xl {
+  font-size: $fontSizeFormXl;
+  height: 2.5rem;
+  padding: .6rem .6rem;
+}
+
 .btn-primary {
   color: white;
+}
+
+.form-input.input-xl {
+    font-size: $fontSizeFormXl;
+    height: 2.5rem;
+    padding: .6rem .6rem;
+  }
+
+
+/* Override Spectre default */
+.breadcrumb .breadcrumb-item:not(:last-child) a {
+    color: $linkBlue;
 }
 
 

--- a/policytool/web/static/variables.css
+++ b/policytool/web/static/variables.css
@@ -8,7 +8,8 @@ $textColor: #002E45;        /* lower contrast text :-) */
 $hoverBorderColor: #8BD1FF; /* border for buttons on hover */
 $footerColor: #F2F4F6;      /* light gray */
 $linkBlue: #007AF5;         /* primary blue, for links */
-$linkBlueHover: #005DB9;         /* primary blue, for links */
+$linkBlueHover: #005DB9;    /* primary blue, for links */
+$linkBlueDisabled: #CCECFD; /* paler blue, for disabled links */
 $borderDark: #CCD8DD;       /* Darker grey for dividers and borders */
 
 /*
@@ -22,6 +23,8 @@ $borderDark: #CCD8DD;       /* Darker grey for dividers and borders */
 $titleBigFontSize: 1.75rem;
 $titleFontSize: 1.125rem;
 $baseFontSize: 1rem;
+
+$fontSizeFormXl: 0.9rem;
 
 @font-face {
     font-family: Wellcome;

--- a/policytool/web/templates.py
+++ b/policytool/web/templates.py
@@ -1,0 +1,74 @@
+import os
+import jinja2
+import falcon
+
+from . import api
+
+
+class TemplateResource:
+    """
+    Serves HTML templates. Note that templates are read from the FS for
+    every request.
+    """
+
+    def __init__(self, template_dir, context=None):
+        api.logger.info('TemplateResource: template_dir=%s', template_dir)
+        self.env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(template_dir),
+            autoescape=jinja2.select_autoescape(['html']),
+        )
+        if context is not None:
+            self.context = context
+        else:
+            self.context = {}
+
+    def on_get(self, req, resp):
+        tnames = to_template_names(req.path)
+        try:
+            template = self.env.select_template(tnames)
+            resp.body = template.render(**self.context)
+            resp.content_type = 'text/html'
+        except jinja2.TemplateNotFound:
+            resp.status = falcon.HTTP_404
+            return
+
+
+def to_template_names(path):
+    """
+    Maps HTTP request paths to Jinja template paths.
+
+    Args:
+        path: path portion of HTTP GET request
+
+    Returns:
+        Tuple of file paths that Jinja should search for.
+    """
+
+    if not path.startswith('/'):
+        raise ValueError
+    path = path[1:]  # remove leading /, jinja won't want it
+
+    if os.path.basename(path).startswith('_'):
+        # Macros are kept in templates starting with _; don't allow
+        # access to them.
+        return tuple()
+
+    if path == '':
+        return ('index.html',)
+
+    if path.endswith('/'):
+        return (
+            path[:-1] + '.html',
+            os.path.join(path, 'index.html'),
+        )
+
+    if path.endswith('.html'):
+        return (
+            path,
+            os.path.join(path[:-5], 'index.html'),
+        )
+
+    return (
+        path + '.html',
+        os.path.join(path, 'index.html'),
+    )

--- a/policytool/web/templates/index.html
+++ b/policytool/web/templates/index.html
@@ -25,7 +25,7 @@
         <h3>Search through Policy Documents</h3>
         <p>We have pulled in the PDFs of UNICEF, MSF, NICE, WHO and the UK Parliament. Our tool allows you to search across these documents.</p>
         <div class="buttons">
-          <a class="btn btn-primary hero-button" href="/search">
+          <a class="btn btn-primary hero-button" href="/search/content">
             Search through Policy Documents <i class="icon icon-arrow-right"></i></a>
         </div>
       </div>

--- a/policytool/web/templates/results/content.html
+++ b/policytool/web/templates/results/content.html
@@ -1,0 +1,139 @@
+{% extends 'base.html' %}
+
+{% block main %}
+
+<div class="breadcrumb-box">
+    <div class="container">
+        <div class="columns">
+            <div class="column col-12">
+                <ul class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="/">Home</a></li>
+                    <li class="breadcrumb-item">Search the contents of Policy Documents</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="results-box">
+    <div class="container">
+        <div class="columns">
+
+            {% if es_response.hits.hits %}
+                <div class="column col-12 col-md-12">
+                    <h1>Policy Documents results for "{{ term }}"</h1>
+                </div>
+            {% else %}
+                <div class="column col-12 col-md-12">
+                    <h1>No search results for "{{ term }}"</h1>
+                    <p>Check the spellingm try alternate words or a more generic term.</p>
+                </div>
+            {% endif %}
+            <div class="column col-12 col-md-12">
+                <p>Search the contents of Policy Documents(title, abstract, author)</p>
+            </div>
+            <div class="column col-6 col-md-12">
+                <form action="/results/content">
+                    <div class="input-group">
+                      <input type="text" class="form-input input-xl" placeholder="Search" name="term" id="search-term" value="{{ term }}">
+                      <span id="search-clear" class="input-group-addon addon-lg"><i class="form-icon icon icon-cross"></i></span>
+                      <button type="submit" class="btn btn-primary input-group-btn btn-xl">Search</button>
+                    </div>
+                </form>
+                <div class="search-tips">
+                    <a href="#">Advanced search tips</a>
+                    <div class="popover popover-bottom">
+                      <span class="btn help">?</span>
+                      <div class="popover-container">
+                        <div class="card">
+                          {{ uparrow() }}
+                          <div class="card-body">
+                            Policy tool regularly loads the PDFs of WHO, MSF, UNICEF, NICE, and other
+                            organizations. Click this button to search the text of these documents.
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+            {% if es_response.hits.hits %}
+                <div class="column col-6 col-md-12 text-right">
+                    <a class="btn btn-primary btn-xl" href="#" >Download results as .csv</a>
+                </div>
+            {% else %}
+                <div class="column col-6 col-md-12"></div>
+            {% endif %}
+        </div>
+    </div>
+    {% if es_response.hits.hits %}
+        <div class="container">
+            <div class="columns">
+                <div class="column col-6 col-md-12">
+                    {{ (page - 1) * size + 1 }} - {{ [(page - 1) * size + size, es_response.hits.total.value] | min }} of {{ es_response.hits.total.value }} results
+                </div>
+                <div class="column col-6 col-md-12">
+                    <div class="pagination-box float-right">
+
+                        <ul class="pagination">
+                            {% if page > 1 %}
+                                   <li class="page-item">
+                                    <a href="/results/content?term={{ term }}&page={{ page - 1 }}">Prev</a>
+                                </li>
+                            {% else %}
+                                <li class="page-item disabled">
+                                    <a href="#" tabindex="-1">Prev</a>
+                                </li>
+                            {% endif %}
+                            {% for n_page in pages %}
+                                <li class="page-item {% if n_page == page %}active{% endif %}">
+                                    <a href="/results/content?term={{ term }}&page={{ n_page }}">{{ n_page }}</a>
+                                </li>
+                            {% endfor %}
+                            {% if page < pages|length %}
+                                   <li class="page-item">
+                                    <a href="/results/content?term={{ term }}&page={{ page + 1 }}">Next</a>
+                                </li>
+                            {% else %}
+                                <li class="page-item disabled">
+                                    <a href="#" tabindex="-1">Next</a>
+                                </li>
+                            {% endif %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="results">
+            <div class="container">
+                <table class="table table-bordered table-hover">
+                    <thead>
+                        <tr>
+                            <th>Policy Document</th>
+                            <th>Organisation</th>
+                            <th>Author(s)</th>
+                            <th>Year of publication</th>
+                        </tr>
+                    </thead>
+                     <tbody>
+                        {% for hit in es_response.hits.hits %}
+                            <tr>
+                                <td>
+                                    {% if hit._source.doc.text %}
+                                        {{ hit._source.doc.text | truncate(60) }}
+                                    {% else %}
+                                        No title
+                                    {% endif %}
+                                    </td>
+                                <td>{{ hit._source.doc.organisation }}</td>
+                                <td>{{ hit._source.doc.authors }}</td>
+                                <td>{{ hit._source.doc.year }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/policytool/web/templates/search/citations.html
+++ b/policytool/web/templates/search/citations.html
@@ -1,0 +1,78 @@
+{% extends 'base.html' %}
+
+{% block main %}
+<div class="breadcrumb-box">
+    <div class="container">
+        <div class="columns">
+            <div class="column col-12">
+                <ul class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="/">Home</a></li>
+                    <li class="breadcrumb-item">Find Research Publications cited by Policy Documents</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="search-box">
+    <div class="container">
+        <div class="columns">
+            <div class="column col-5 col-md-12">
+                <h1>Find Research Publications cited by Policy Documents</h1>
+                <p>We have pulled in the PDFs of UNICEF, MSF, NICE, WHO and the UK Parliament. Our tool alllows you to search across these documents.</p>
+            </div>
+            <div class="column col-1 col-md-12"></div>
+            <div class="column col-6 col-md-12">
+                <p>Search the contents of Policy Documents(title, abstract, author)</p>
+                <form action="/results/content">
+                    <div class="input-group">
+                      <input type="text" class="form-input input-lg" placeholder="Search" name="term" id="search-term">
+                      <span id="search-clear" class="input-group-addon addon-lg"><i class="form-icon icon icon-cross"></i></span>
+                      <button type="submit" class="btn btn-primary input-group-btn btn-lg">Search</button>
+                    </div>
+                </form>
+                <div class="search-tips">
+                    <a href="#">Advanced search tips</a>
+                    <div class="popover popover-bottom">
+                      <span class="btn help">?</span>
+                      <div class="popover-container">
+                        <div class="card">
+                          {{ uparrow() }}
+                          <div class="card-body">
+                            Policy tool regularly loads the PDFs of WHO, MSF, UNICEF, NICE, and other
+                            organizations. Click this button to search the text of these documents.
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="insights">
+    <div class="container">
+        <div class="columns">
+            <div class="column col-6 col-md-12">
+                <h3>Key insights</h3>
+            </div>
+            <div class="column col-6 col-md-12">
+
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="text/javascript">
+    // TODO: This should go in a compiled JS file
+    window.onload = function () {
+        let searchInput = document.getElementById('search-term');
+        document.getElementById('search-clear').addEventListener('click', function () {
+            searchInput.value = '';
+        });
+    }
+</script>
+{% endblock %}

--- a/policytool/web/templates/search/content.html
+++ b/policytool/web/templates/search/content.html
@@ -24,9 +24,9 @@
             <div class="column col-1 col-md-12"></div>
             <div class="column col-6 col-md-12">
                 <p>Search the contents of Policy Documents(title, abstract, author)</p>
-                <form action="/search/result">
+                <form action="/results/content">
                     <div class="input-group">
-                      <input type="text" class="form-input input-lg" placeholder="Search" name="search-term" id="search-term">
+                      <input type="text" class="form-input input-lg" placeholder="Search" name="term" id="search-term">
                       <span id="search-clear" class="input-group-addon addon-lg"><i class="form-icon icon icon-cross"></i></span>
                       <button type="submit" class="btn btn-primary input-group-btn btn-lg">Search</button>
                     </div>


### PR DESCRIPTION
# Description

Implements the new search results API page, as well as fixing a few other design issues and refactoring the template rendering methods:

 - Add new routes for a templates search results page
 - Change search form action route
 - Changes the template class and architecture
   - The template class can now be used as a base class in other api calls
   - changes the template architecture to reflect the search/results routes of the api
 - Use Spectre base classes to define btn-xl and input-xl.
 - Changes and add to the design
   - Add a result page css file
   - Move some of the search page css to the global style design
   - Define some sizes for the new xl sized fields
   - Define a table-bordered class (similar to bootstrap's)
   - a few other minor tweaks
 - Fix the gulpfile 

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature

# How Has This Been Tested?

`make docker-test`
Local runs on Docker with 2CPU, 10.5GiB memory
