### PR TITLE
Fix Elasticsearch indices

### DIFF
--- a/policytool/airflow/dags/policy.py
+++ b/policytool/airflow/dags/policy.py
@@ -36,12 +36,15 @@ ItemLimits = namedtuple('ItemLimits', ('spiders', 'index'))
 # Configuration & paths
 #
 
+
 def verify_s3_prefix():
     reach_s3_prefix = conf.get("core", "reach_s3_prefix")
     assert reach_s3_prefix.startswith('s3://')
     assert not reach_s3_prefix.endswith('/')
 
+
 verify_s3_prefix()
+
 
 def get_es_hosts():
     result = conf.get("core", "elasticsearch_hosts")
@@ -109,7 +112,7 @@ def create_org_pipeline(dag, organisation, item_limits, spider_years):
         organisation=organisation,
         es_host='elasticsearch',
         item_limits=item_limits.index,
-        es_index='-'.join([dag.dag_id, 'policy-docs']),
+        es_index='-'.join([dag.dag_id, 'docs']),
         dag=dag
     )
 
@@ -140,7 +143,7 @@ def create_org_pipeline(dag, organisation, item_limits, spider_years):
         organisation=organisation,
         es_host='elasticsearch',
         item_limits=item_limits.index,
-        es_index='-'.join([dag.dag_id, 'policy-docs']),
+        es_index='-'.join([dag.dag_id, 'citations']),
         dag=dag
     )
 

--- a/policytool/airflow/tasks/es_index_fulltext_docs.py
+++ b/policytool/airflow/tasks/es_index_fulltext_docs.py
@@ -52,7 +52,7 @@ class ESIndexFulltextDocs(BaseOperator):
         s3 = WellcomeS3Hook()
 
         # TODO: implement skipping mechanism
-        fulltext_docs.clean_es(es, self.es_index)
+        fulltext_docs.clean_es(es, self.es_index, self.organisation)
 
         if self.max_items:
             self.log.info(

--- a/policytool/airflow/tasks/es_index_fuzzy_matched.py
+++ b/policytool/airflow/tasks/es_index_fuzzy_matched.py
@@ -54,7 +54,7 @@ class ESIndexFuzzyMatchedCitations(BaseOperator):
         s3 = WellcomeS3Hook()
 
         # TODO: implement skipping mechanism
-        fuzzy_matched_citations.clean_es(es, self.es_index)
+        fuzzy_matched_citations.clean_es(es, self.es_index, self.organisation)
 
         self.log.info(
             'Getting %s pubs from %s',

--- a/policytool/elastic/fulltext_docs.py
+++ b/policytool/elastic/fulltext_docs.py
@@ -10,6 +10,7 @@ import functools
 import json
 import logging
 
+
 from . import common
 
 CHUNK_SIZE = 50  # tuned for large(ish) size of policy docs
@@ -28,9 +29,21 @@ def to_es_action(org, es_index, line):
     }
 
 
-def clean_es(es, es_index):
-    """ Ensure an empty index exists. """
-    common.clean_es(es, es_index)
+def clean_es(es, es_index, org):
+    """ Ensure an empty index exists and delete documents from the
+    organisation to ensure no duplicates are inserted.
+    """
+    es_body = {
+        'query': {
+            'match': {
+                'organisation': org,
+            }
+        }
+    }
+    es.delete_by_query(
+        index=es_index,
+        body=es_body,
+    )
 
 
 def insert_file(f, es, org, es_index, max_items=None):

--- a/policytool/elastic/fuzzy_matched_citations.py
+++ b/policytool/elastic/fuzzy_matched_citations.py
@@ -32,9 +32,21 @@ def to_es_action(org, es_index, line):
     }
 
 
-def clean_es(es, es_index):
-    """ Ensure an empty index exists. """
-    common.clean_es(es, es_index)
+def clean_es(es, es_index, org):
+    """ Ensure an empty index exists and delete documents from the
+    organisation to ensure no duplicates are inserted.
+    """
+    es_body = {
+        'query': {
+            'match': {
+                'organisation': org,
+            }
+        }
+    }
+    es.delete_by_query(
+        index=es_index,
+        body=es_body,
+    )
 
 
 def insert_file(f, es, org, es_index, max_items=None):


### PR DESCRIPTION
# Description

🚨 This will change the name of the indices used in Elasticsearch 🚨 

Fix a few incoherence on ES indices:

 - No more indices called "policy-policy-X" or "policy-policy-test-X", just "policy-X" or "policy-test-X"

 - Fixed an issue where we only kept the last organisation results (one task per organisation, but full index clean every task)

## Type of change

- [x] :bug: Bug fix

# How Has This Been Tested?

`make docker-test`

Local test and full runs on Docker with 2CPU, 10.5GiB memory
