### PR TITLE
docker-compose: Updates to make running local dev smoother

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,10 +84,10 @@ services:
           memory: "40M"
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.2.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.2.1
     environment:
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx2g"
     ports:
       - 127.0.0.1:9200:9200
     volumes:
@@ -189,6 +189,7 @@ services:
       - ./reach/web:/src/reach/reach/web/
       - ./reach/scraper:/src/reach/reach/scraper/
       - ./build/web:/build/web
+    depends_on: ['elasticsearch']
     deploy:
       resources:
         limits:


### PR DESCRIPTION
# Description

Updates to `docker-compose` to 

* Updated elasticsearch image to 7.2.1 from 7.2.0 as there was an issue
in 7.2.0 with a file creation race of some type (more information here https://github.com/elastic/cloud-on-k8s/issues/1076)
* Updated JVM options for elastic search to start with a lower heap
allocation than max heap allocation to speed up start and avoid
`OutOfMemory` issues.
* Added `depends_on` param to `web` service for elasticsearch to avoid help mitigate races on startup of containers.

## Type of change

Untracked issues, arising from initial set up of repo for local development.

- [x ] :bug: Bug fix

# How Has This Been Tested?

Local testing of run of `docker-compose` and confirmation that all services are running.

```
➜  reach git:(update-dev-docker-setup) docker-compose ps
WARNING: The AWS_SESSION_TOKEN variable is not set. Defaulting to a blank string.
WARNING: The SENTRY_DSN variable is not set. Defaulting to a blank string.
WARNING: Some services (airflow-scheduler, airflow-web, airflow-worker, elasticsearch, gulp-watch, postgres, redis, web) use the 'deploy' key, which will be ignored. Compose does not support 'deploy' configuration - use `docker stack deploy` to deploy to a swarm.
          Name                         Command               State                 Ports
-------------------------------------------------------------------------------------------------------
reach_airflow-scheduler_1   /src/reach/reach/scraper/p ...   Up
reach_airflow-web_1         /src/reach/reach/scraper/p ...   Up      127.0.0.1:8080->8080/tcp
reach_airflow-worker_1      airflow worker                   Up
reach_elasticsearch_1       /usr/local/bin/docker-entr ...   Up      127.0.0.1:9200->9200/tcp, 9300/tcp
reach_gulp-watch_1          docker-entrypoint.sh gulp  ...   Up
reach_postgres_1            docker-entrypoint.sh postgres    Up      127.0.0.1:5432->5432/tcp
reach_redis_1               docker-entrypoint.sh redis ...   Up      127.0.0.1:6379->6379/tcp
reach_web_1                 gunicorn --bind=0.0.0.0:80 ...   Up      127.0.0.1:8081->8081/tcp
```

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
