### PR TITLE
docker and docker-compose: Updates to file paths to clean up dirs (Fix #266)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,28 @@
 # Use a basic Python image
 FROM reach.base
 
-COPY setup.py /src/reach/
-COPY README.md /src/reach/
-COPY unpinned_requirements.txt /src/reach/
-COPY reach/ /src/reach/reach/
+COPY setup.py /opt/reach
+COPY README.md /opt/reach
+COPY unpinned_requirements.txt /opt/reach
+COPY reach/ /opt/reach/reach/
 
 # Airflow deps
 COPY reach/scrapy.cfg /etc/scraper/scrapy.cfg
 
-COPY build/web/ /build/web/
-ENV STATIC_ROOT=/build/web/static
+COPY build/web/ /opt/reach/build/web/
+ENV STATIC_ROOT=/opt/reach/build/web/static
 
 # TODO: cd /src after we've moved setup.py up a dir
-RUN /bin/sh -c 'cd /src/reach && python3 setup.py develop --no-deps'
+RUN /bin/sh -c 'cd /opt/reach && python3 setup.py develop --no-deps'
 
 # Airflow
-COPY reach/airflow/airflow.cfg /airflow/
-COPY reach/airflow/initdb.sh /airflow/
-RUN mkdir -p /airflow/db && \
-    ln -s /src/reach/reach/airflow/dags /airflow/dags && \
-    chmod +x /airflow/initdb.sh && \
-    chown -R www-data: /airflow
+COPY reach/airflow/airflow.cfg /opt/airflow/
+COPY reach/airflow/initdb.sh /opt/airflow/
+RUN mkdir -p /opt/airflow/db && \
+    ln -s /opt/reach/reach/airflow/dags /opt/airflow/dags && \
+    chmod +x /opt/airflow/initdb.sh && \
+    mkdir -p /opt/airflow/logs && \
+    chmod -R 777 /opt/airflow/logs && \
+    chown -R www-data: /opt/airflow
 
 USER www-data

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -7,8 +7,8 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV LANGUAGE=C.UTF-8
 
-WORKDIR /reach
-COPY requirements.txt /reach/requirements.txt
+WORKDIR /opt/reach
+COPY requirements.txt /opt/reach/requirements.txt
 
 # Poppler is needed to run pdftotext convertion
 RUN apt-get update -yqq && \

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test: virtualenv
 docker-test: docker-build
 	docker run -u root -v $$(pwd)/test_requirements.txt:/test_requirements.txt \
 		--rm $(ECR_IMAGE):$(VERSION) \
-		sh -c "pip3 install -r /test_requirements.txt && pytest /src/reach"
+		sh -c "pip3 install -r /test_requirements.txt && pytest /opt/reach"
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-airflow-image: &airflow-image
   160358319781.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/reach:latest
 
 x-airflow_env: &airflow-env
-  AIRFLOW_HOME: /airflow
+  AIRFLOW_HOME: /opt/airflow
 
   # S3 prefix for all datalabs operators.
   # (in `core` because we must be in an existing section of the cfg)
@@ -38,10 +38,10 @@ x-airflow_env: &airflow-env
   DATABASE_URL: "postgresql://postgres:development@postgres:5432/wsf_scraping"
 
 x-airflow-volumes: &airflow-volumes
-  - ./reach/airflow/airflow.cfg:/airflow/airflow.cfg
-  - ./reach/airflow/initdb.sh:/airflow/initdb.sh
-  - ./reach:/src/reach/reach
-  - ./build/airflow.db:/airflow/db
+  - ./reach/airflow/airflow.cfg:/opt/airflow/airflow.cfg
+  - ./reach/airflow/initdb.sh:/opt/airflow/initdb.sh
+  - ./reach:/opt/reach/reach
+  - ./build/airflow.db:/opt/airflow/db
 
 # Restart airflow several times in case the DB wasn't present.
 # (Yes, we could netcat, but postgres can accept TCP conns before
@@ -112,10 +112,10 @@ services:
       <<: *airflow-env
       POSTGRES_DSN: "postgresql://postgres:development@postgres:5432/airflow?connect_timeout=20"
     command:
-      - /src/reach/reach/scraper/pg_isready.py
+      - /opt/reach/reach/scraper/pg_isready.py
       - sh
       - "-cx"
-      - "/airflow/initdb.sh && exec airflow scheduler"
+      - "/opt/airflow/initdb.sh && exec airflow scheduler"
     volumes: *airflow-volumes
     depends_on: ["postgres", "redis"]
     deploy:
@@ -137,7 +137,7 @@ services:
       # in place.
       # Thus pg_isready.py, and with a longer success-secs than
       # airflow-scheduler.
-      - /src/reach/reach/scraper/pg_isready.py
+      - /opt/reach/reach/scraper/pg_isready.py
       - "--timeout=30"
       - "--success-secs=8"  # allow extra time for initdb to get started
       - airflow
@@ -176,7 +176,7 @@ services:
       AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
       SENTRY_DSN: "${SENTRY_DSN}"
-      STATIC_ROOT: /build/web/static
+      STATIC_ROOT: /opt/reach/build/web/static
       ELASTICSEARCH_HOST: "http://elasticsearch:9200"
       # DATABASE_URL: "postgres://postgres:postgres@articles-db:5432/wsf_scraping"
 
@@ -186,14 +186,15 @@ services:
       - --reload
       - reach.web.wsgi:application
     volumes:
-      - ./reach/web:/src/reach/reach/web/
-      - ./reach/scraper:/src/reach/reach/scraper/
-      - ./build/web:/build/web
+      - ./reach/web:/opt/reach/reach/web/
+      - ./reach/scraper:/opt/reach/reach/scraper/
+      - ./build/web:/opt/reach/build/web
     depends_on: ['elasticsearch']
     deploy:
       resources:
         limits:
           memory: "64M"
+
 
   # TODO: run gulp watch with the right volumes in place
   # and update the web image to serve static from build/static
@@ -204,9 +205,9 @@ services:
       - gulp
       - watch
     volumes:
-      - ./build/web/static:/src/build/static
-      - ./reach/web/gulpfile.js:/src/gulpfile.js
-      - ./reach/web/static:/src/static
+      - ./build/web/static:/opt/reach/build/web/static
+      - ./reach/web/gulpfile.js:/opt/reach/build/web/gulpfile.js
+      - ./reach/web/static:/opt/reach/build/web/src
     # Signal handling in gulp? Not so much...
     stop_signal: SIGKILL
     deploy:

--- a/reach/airflow/airflow.cfg
+++ b/reach/airflow/airflow.cfg
@@ -3,11 +3,11 @@
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository
 # This path must be absolute
-dags_folder = /airflow/dags
+dags_folder = /opt/airflow/dags
 
 # The folder where airflow should store its log files
 # This path must be absolute
-base_log_folder = /airflow/logs
+base_log_folder = /opt/airflow/logs
 
 # Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
 # Users must supply an Airflow connection id that provides access to the storage
@@ -81,7 +81,7 @@ max_active_runs_per_dag = 16
 load_examples = False
 
 # Where your Airflow plugins are stored
-plugins_folder = /airflow/plugins
+plugins_folder = /opt/airflow/plugins
 
 # Secret key to save connection passwords in the db
 # set by AIRFLOW__CORE__FERNET_KEY
@@ -389,7 +389,7 @@ dag_dir_list_interval = 300
 # How often should stats be printed to the logs
 print_stats_interval = 30
 
-child_process_log_directory = /airflow/logs/scheduler
+child_process_log_directory = /opt/airflow/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has
 # not heartbeat in this many seconds, the scheduler will mark the

--- a/reach/airflow/initdb.sh
+++ b/reach/airflow/initdb.sh
@@ -2,7 +2,7 @@
 
 if echo $AIRFLOW__CORE__SQL_ALCHEMY_CONN | grep -q postgres
 then
-    if ! /src/reach/scraper/pg_exists.py dag; then
+    if ! /opt/reach/reach/scraper/pg_exists.py dag; then
         # airflow upgradedb gets us a working DB from empty, but without all
         # the extra connections.
         # cf. https://medium.com/datareply/airflow-lesser-known-tips-tricks-and-best-practises-cf4d4a90f8f

--- a/reach/web/Dockerfile.node
+++ b/reach/web/Dockerfile.node
@@ -3,7 +3,7 @@ FROM node:12.7.0-alpine
 # Rationale: install modules into /src/node_modules, which
 # we keep inside the docker image. Then, volume in whatever
 # grunt needs to run.
-WORKDIR /src
+WORKDIR /opt/reach/build/web
 RUN \
     npm install -g gulp && \
     npm install \
@@ -17,6 +17,6 @@ RUN \
         postcss-import \
         postcss-url
 
-VOLUME ["/src/build/static", "/src/gulpfile.js", "/src/static"]
+VOLUME ["/opt/reach/build/web/src", "/opt/reach/build/web/gulpfile.js", "/opt/reach/build/web/static"]
 
 CMD ["gulp", "watch"]

--- a/reach/web/bin/docker_run.sh
+++ b/reach/web/bin/docker_run.sh
@@ -10,8 +10,8 @@ BUILD_DIR=$(cd $(dirname $0)/../../../build/web/static; pwd)
 docker run \
     --rm \
     -e NODE_ENV=production \
-    -v $BUILD_DIR/:/build/web/static \
-    -v $DIR/gulpfile.js:/src/gulpfile.js \
-    -v $DIR/static:/src/static \
+    -v $BUILD_DIR/:/opt/reach/build/web/static \
+    -v $DIR/gulpfile.js:/opt/reach/build/web/gulpfile.js \
+    -v $DIR/static:/opt/reach/reach/web/static \
     reach-web-build:latest \
     $*

--- a/reach/web/gulpfile.js
+++ b/reach/web/gulpfile.js
@@ -19,16 +19,16 @@ exports.css = function() {
         require('cssnano')
   ];
 
-  return src('static/**/*.css')
+  return src('src/**/*.css')
     .pipe( sourcemaps.init() )
     .pipe( postcss(plugins) )
     // sourcemaps are rooted in dest(), so '.' is what we want
     .pipe( sourcemaps.write('.') )
-    .pipe( dest('/src/build/static') );
+    .pipe( dest('/opt/reach/build/web/static') );
 };
 
 exports.default = parallel(exports.css);
 
 exports.watch = function() {
-  watch('static/*.css', {ignoreInitial: false}, exports.css);
+  watch('src/*.css', {ignoreInitial: false}, exports.css);
 };


### PR DESCRIPTION
# Description

**Note** There are appropriate changes coming to the infra repo in support of these changes as well. As well, as I'm relatively new to the repo, if there's anything I've missed or not considered please let me know and I'll revise.

* Updated file paths to be based in  folder inside containers versus the root of the file system
* Updated gulp watch and gupl build paths to use new paths in
* Updated airflow and other dependents to use  filepaths
* Organized copies into  and  folders under opt for easier debugging inside of containers

This commit mainly consists of changes to various path configurations throughout in order to get a more concrete clean set of directories set up with predictable paths.

The main issue this addresses is that up until this change files, and folders were being mapped into the root of the filesystem which is less than ideal as they are interspersed between system paths/folders making reasonoing about where everything is a bit more difficult than it should be.

A normal standard for how to handle this (one of many) is to use the `/opt` directory on the filesystem to organize applications which are **optional** for the operating system. If we were compiling binaries we might want to move compiled artefacts into `/usr/local/bin` and `/etc/<app_name>` for instance but because we are deploying source code (i.e. python) into the container it makes more sense for it to go into `/opt`.

The other part of this is to make reasoning about paths in the different containers for things further down the line like k8s configuration of ENV variables easier. At first, reading through the Dockerfiles, docker-compose.yml, etc... it was very hard to tell where things were being laid out. Hopefully these changes have made this a little easier and the paths more concrete.

The result of this is that we end up with two main directories under `/opt`

1. `/opt/reach` for application code
2. `/opt/airflow` for airflow config, etc...

The gulp watch runs against `/opt/reach/build/web` 

## Type of change

- [x] :bug: Bug fix

# How Has This Been Tested?

1. Docker tests ran and completed fine.
1. Tested sites working and operational in local dev
1. Tested and ran individual DAG paths to ensure file paths were not effected

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
