### PR TITLE
gulp: Path/Volume fixes (Fix #266)

### DIFF
--- a/reach/web/Dockerfile.node
+++ b/reach/web/Dockerfile.node
@@ -17,6 +17,6 @@ RUN \
         postcss-import \
         postcss-url
 
-VOLUME ["/src/build/static", "/src/gulpfile.js", "/src/static"]
+VOLUME ["/build/web/static", "/src/gulpfile.js", "/src/static"]
 
 CMD ["gulp", "watch"]

--- a/reach/web/gulpfile.js
+++ b/reach/web/gulpfile.js
@@ -24,7 +24,7 @@ exports.css = function() {
     .pipe( postcss(plugins) )
     // sourcemaps are rooted in dest(), so '.' is what we want
     .pipe( sourcemaps.write('.') )
-    .pipe( dest('/src/build/static') );
+    .pipe( dest('/build/web/static') );
 };
 
 exports.default = parallel(exports.css);


### PR DESCRIPTION
# Description

* gulp build path didn't match with -v mount in `docker_run.sh`
* Dockerfile.node VOLUMES did not match against  args and commands

## Type of change

- [x] :bug: Bug fix

# How Has This Been Tested?

Changes tested manually locally from a clean slate state.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
