### PR TITLE
Remove dependency on export_env.py; update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,32 @@
 # Contributing
 
-:tada: First of all, welcome to this repository, and thanks for your interest, whether you want to contribute
-or simply are interested in opening an issue.
+:tada: First of all, welcome to this repository, and thanks for your
+interest, whether you want to contribute or simply are interested in
+opening an issue.
 
-When contributing to this repository, please first discuss the change you wish to make by creating an issue before making a change.
+When contributing to this repository, please first discuss the change
+you wish to make by creating an issue before making a change.
 
-Please note we have a code of conduct, please follow it in all your interactions with the project.
+Please note we have a code of conduct, please follow it in all your
+interactions with the project.
 
 ## Pull Request Process
 
-1. Before pushing your code, please make sure to have it covered by some unit tests. Also make sure that the code passes both your tests and the other tests.
+1. Before pushing your code, please make sure to have it covered by some
+   unit tests. Please also make sure that the code passes both your
+   tests and the other tests. Finally, please create clear, logically
+   grouped commits and commit messages. Most any style guide will do;
+   here's [a historical one for any divers in the
+   team](https://github.com/torvalds/subsurface-for-dirk/blob/a48494d2fbed58c751e9b7e8fbff88582f9b2d02/README#L88).
 
-2. Use our pull request template to submit any changes to the code, even minor.
+2. Use the automatic pull request template to submit changes, even
+   minor.
 
-3. This project is developed using Python3.6 (currently the last Python version),
-   and follow the PEP8 (https://www.python.org/dev/peps/pep-0008/) rules. You should enforce this
-   behaviour and also use Pyflakes to check your code for unused libraries.
+3. This project is developed using Python 3.6 and 3.7 (though later
+   versions should work, too), and it follows the PEP8
+   (https://www.python.org/dev/peps/pep-0008/) rules. You should enforce
+   this behaviour and also use Pyflakes to check your code for unused
+   libraries.
 
 ## Style
 
@@ -23,6 +34,8 @@ The following style guides are recommended:
 
 - [Google JSON Style Guide](https://google.github.io/styleguide/jsoncstyleguide.xml)
 - [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
+- [the above short note on commit
+  messages](https://github.com/torvalds/subsurface-for-dirk/blob/a48494d2fbed58c751e9b7e8fbff88582f9b2d02/README#L88)
 
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wellcome Reach
 
 Wellcome Reach is an open source service for discovering how research
-publications are being cited in global policy documents, including those
+publications are cited in global policy documents, including those
 produced by policy organizations such as the WHO, MSF, and the UK
 government. Key parts of it include:
 
@@ -15,12 +15,13 @@ government. Key parts of it include:
    produced above.
 
 Wellcome Reach is written in Python and developed using docker-compose.
+It's deployed into Kubernetes.
 
 Although parts of the Wellcome Reach have been in use at Wellcome since
-mid-2018, the project has only just gone open source starting in March
-2019. Given these early days, please be patient as various parts of it
-are made accessible to external users. All issues and pull requests
-are welcome. Contributing guidelines can be found in
+mid-2018, the project has only been open source since March 2019. Given
+these early days, please be patient as various parts of it are made
+accessible to external users. All issues and pull requests are welcome.
+Contributing guidelines can be found in
 [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Development
@@ -44,7 +45,7 @@ To bring up the development environment using docker:
     make docker-build
     docker-compose up -d
     ```
-1. Verify came up with:
+1. Verify it all came up with:
     ```
     docker-compose ps
     ```
@@ -58,7 +59,7 @@ Once up, you'll be able to access:
 
 ### virtualenv
 
-For local development outside of airflow or other services, just use the
+For local development outside of airflow or other services, use the
 project's virtualenv:
 
 ```
@@ -128,7 +129,6 @@ For production, a typical deployment uses:
 - a PostgreSQL or MySQL database for Airflow to use
 - a distributed storage service such as S3
 - an ElasticSearch cluster for searching documents
-
 
 ## Evaluating each component of the algorithm
 

--- a/README.md
+++ b/README.md
@@ -31,28 +31,14 @@ To develop for this project, you will need:
 
 1. Python 3.6+, plus `pip` and `virtualenv`
 1. Docker and docker-compose
-1. AWS credentials with read/write S3 permissions.
-1. A clean json file containing reference sections (TODO: remove this by
-   pulling from a public S3 bucket by default)
-1. A clean csv file containing all your references (TODO: remove this by
-   pulling from a public S3 bucket by default)
+1. AWS credentials with read/write S3 permissions to an S3 bucket
+   of your choosing.
 
 ### docker-compose
 
 To bring up the development environment using docker:
 
 1. Set your AWS credentials into your environment. (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
-1. If you don't have Wellcome IAM creds, run: (TODO: remove this step)
-    ```
-    export 
-        DIMENSIONS_USERNAME="" \
-        DIMENSIONS_PASSWORD="" \
-        AIRFLOW_FERNET_KEY=""
-    ```
-1. If you do, simply run:
-    ```
-    eval $(./export_env.py)
-    ```
 1. Build and start the env with:
     ```
     make docker-build
@@ -121,6 +107,19 @@ then on the console. To do this, from top of the project directory:
 	    2018-11-02 -tp '${JSON_PARAMS}'
     ```
 
+### For developers inside Wellcome
+
+Although not required, you can add Sentry reporting from your local dev
+environment to a localdev project inside Wellcome's sentry account by
+running:
+
+    ```
+    eval $(./export_wellcome_env.py)
+    ```
+
+before running `docker-compose up -d` above.
+
+
 ## Deployment
 
 For production, a typical deployment uses:
@@ -156,4 +155,5 @@ You can read more about how we got the evaluation data and what the evaluation r
 - [reach/refparse/README.md](reach/refparse/README.md)
 
 ## Contributing
+
 See the [Contributing guidelines](./CONTRIBUTING.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ x-airflow_env: &airflow-env
   # dev creds encryption key, cf.
   # https://airflow.readthedocs.io/en/stable/howto/secure-connections.html
   # (but not used; everything's from env atm)
-  AIRFLOW__CORE__FERNET_KEY: "${AIRFLOW_FERNET_KEY}"
+  AIRFLOW__CORE__FERNET_KEY: "Hdse5UohkZRNITjzWt3f1kcYAPJE5LHcBbZnkVNV4_4="
 
   # Wait 20s to connect to PostgreSQL, in case it's coming up fresh.
   AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql://postgres:development@postgres:5432/airflow?connect_timeout=20"

--- a/export_wellcome_env.py
+++ b/export_wellcome_env.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 
 """
-Prints the environment variables used for developing in this repo,
-after decrypting them using AWS KMS.
-Depends on `aws` (from awscli) being in your path, but not boto3.
+Prints environment variables that are not required, but that can help
+Wellcome employees when developing in this repo. (Only one variable is
+provided just now: SENTRY_DSN, so that exceptions in localdev can be
+inspected from the Sentry UI.)
+
+Depends on:
+
+    - `aws` (from awscli) being in your path, but not boto3.
+    - Wellcome AWS credentials that support decrypting the ciphertext
+      below.
+
 NB: to update the ciphertext:
 ```
 export_env.py -r > /tmp/creds.sh
@@ -25,7 +33,7 @@ parser = ArgumentParser(description=__doc__.strip())
 parser.add_argument('-r', dest='raw', action='store_true',
                     help='Print raw plaintext instead of removing \\s')
 
-CIPHERTEXT_BLOB = "AQICAHhguvwpM7IxTcll8NLhRiUH41+cNUymMx+YBOtLWUn7ogGyCOeYnH+HdZOq0nCQY159AAABZDCCAWAGCSqGSIb3DQEHBqCCAVEwggFNAgEAMIIBRgYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwt4TsxrEXrc5fqTcUCARCAggEXpcs6/PuMMjusKgfCGt0KHYvm4kSTXtk3TkTsL2gxyr9+lBpHocuktzYrQo3gjagaBEms25yk2eW26BnNfjp0NooAYDlBM9TrMeCke67ulH/NqnN6vCXuHzAdBPTKY/bMddE34Rs7B8rWy9qivQqPuI7AaxIQ/o58Knx3i+2fl9uph6PVZ+sC13MSQV/r8KmmOl2AfMZKUd/KHRiB1HA3Q3ywhnAYM3bh5jaD2I7oYKXQCuY6Q1tUNpU34qJLRPX7jC8dT/daRj97aMAqo2M4DYb/RQNQIed5lba67ljS9Qx4Lj3Drba9r8rd4W0lfw6ftnt9uify2zdtLzajhRSfNambyDolNyYeBV8k1KLHr85/jKaKad2W"
+CIPHERTEXT_BLOB = "AQICAHhguvwpM7IxTcll8NLhRiUH41+cNUymMx+YBOtLWUn7ogHC88/HvpfVAu7FXCAC+54sAAAAsTCBrgYJKoZIhvcNAQcGoIGgMIGdAgEAMIGXBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDD4FDbBSWOIWi5aNEgIBEIBq6uGSuXJ/Jy2cwwC/2KMj/nhvurBbDIL2Q9dIgg9ye/yZR4eGrcGgAOC0iQ58oTJl6F4xhcFk74DFj3xrFiOpK68Ym+bGq4Zre4lHzQYPY4RDr0CHv8Bqy65Pe0GGnF/agmRRwlbDirzcAw=="
 
 
 def decrypt_env():


### PR DESCRIPTION
# Description

Our existing README & tooling required you to have AWS creds capable of decrypting Wellcome-specific ciphertext. Make it so that's not the case, and update docs accordingly. Also update docs to include a note on commit message style.

## Type of change

Please delete options that are not relevant.

- [x] :memo: Documentation update

# How Has This Been Tested?

* Running `docker-compose up` without the additional env vars.
* Running `export_wellcome_env.py` and verifying it prints SENTRY_DSN.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
