### PR TITLE
reach: make refparse default to local model file

### DIFF
--- a/reach/airflow/dags/policy.py
+++ b/reach/airflow/dags/policy.py
@@ -73,15 +73,6 @@ def to_s3_output_dir(dag, *args):
     ) % (dag.dag_id, path, slug)
 
 
-def to_s3_model(*args):
-    """ Returns the S3 URL for to a model, rooted under
-    ${REACH_S3_PREFIX}/models/"""
-    return (
-        '{{ conf.get("core", "reach_s3_prefix") }}'
-        '/models/%s'
-    ) % '/'.join(args)
-
-
 def create_org_pipeline(dag, organisation, item_limits, spider_years):
     """ Creates all tasks tied to a single organisation::
 
@@ -116,12 +107,8 @@ def create_org_pipeline(dag, organisation, item_limits, spider_years):
         dag=dag
     )
 
-    parser_model = to_s3_model(
-        'reference_parser_models',
-        'reference_parser_pipeline.pkl')
     extractRefs = ExtractRefsOperator(
         task_id='ExtractRefs.%s' % organisation,
-        model_path=parser_model,
         src_s3_key=parsePdf.dst_s3_key,
         dst_s3_key=to_s3_output(
             dag, 'extracted-refs', organisation, '.json.gz'),

--- a/reach/airflow/tasks/extract_refs_operator.py
+++ b/reach/airflow/tasks/extract_refs_operator.py
@@ -25,21 +25,18 @@ class ExtractRefsOperator(BaseOperator):
     newline-delimited json.gz file.
 
     Args:
-        model_path: S3 URL to extract refs model
         src_s3_key: S3 URL for input
         dst_s3_key: S3 URL for output
     """
 
     template_fields = (
-        'model_path',
         'src_s3_key',
         'dst_s3_key',
     )
 
     @apply_defaults
-    def __init__(self, model_path, src_s3_key, dst_s3_key, aws_conn_id='aws_default', *args, **kwargs):
+    def __init__(self, src_s3_key, dst_s3_key, aws_conn_id='aws_default', *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.model_path = model_path
         self.src_s3_key = src_s3_key
         self.dst_s3_key = dst_s3_key
         self.aws_conn_id = aws_conn_id
@@ -56,7 +53,6 @@ class ExtractRefsOperator(BaseOperator):
             with gzip.GzipFile(mode='wb', fileobj=dst_rawf) as dst_f:
                 refs = yield_structured_references(
                     self.src_s3_key,
-                    self.model_path,
                     pool_map,
                     logger)
                 for structured_references in refs:

--- a/reach/refparse/settings.py
+++ b/reach/refparse/settings.py
@@ -19,9 +19,6 @@ class BaseSettings:
     STRUCTURED_REFS_FILENAME = 'structured_references.json'
     MATCHED_REFS_FILENAME = 'matched_references.json'
 
-    MODEL_DIR = "s3://{}/reference_parser_models".format(BUCKET)
-    CLASSIFIER_FILENAME = "reference_parser_pipeline.pkl"
-
     MIN_CHAR_LIMIT = 20
     MATCH_TITLE_LENGTH_THRESHOLD = 40
 
@@ -37,7 +34,6 @@ class LocalSettings(BaseSettings):
     DEBUG = True
     S3 = False
     SCRAPER_RESULTS_DIR = "scraper-results"
-    MODEL_DIR = "reference_parser_models"
 
 
 settings_mode = {


### PR DESCRIPTION
# Description

Update the reach reference parser so that it uses the model checked into
the repo by default, instead of pulling from an arbitrary location in
S3.

Also, remove related settings from refparse/settings.py.

## Type of change

Refactor.

# How Has This Been Tested?

1. `make docker-test`
1. Running the `policy-test` DAG from a fresh EC2 instance.
1. Running the `refparse` command line per the README.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] New and existing unit tests pass locally with my changes
