### PR TITLE
scraper/parliament: Fix an issue with file:/// protocol URLs Fix #261

### DIFF
--- a/reach/scraper/tests/mock_sites/gov/3.html
+++ b/reach/scraper/tests/mock_sites/gov/3.html
@@ -1,0 +1,606 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="lte-ie8" lang="en"><![endif]--><!--[if gt IE 8]><!--><html lang="en">
+<!--<![endif]-->
+<head>
+<meta name="csrf-param" content="authenticity_token">
+    <meta charset="utf-8">
+    <title lang="en">
+      Public mental health leadership and workforce development framework - GOV.UK
+  </title>
+
+</head>
+
+  <body>
+    
+
+
+    
+<div id="global-cookie-message" class="gem-c-cookie-banner" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet>
+  <div class="gem-c-cookie-banner__wrapper govuk-width-container">
+    <p class="gem-c-cookie-banner__message">GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised. By continuing to use this site, you agree to our use of cookies.</p>
+    <div class="gem-c-cookie-banner__buttons">
+      <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept">
+        
+
+
+  <button class="gem-c-button govuk-button gem-c-button--secondary gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept cookies</button>
+
+
+      </div>
+      <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings">
+        
+
+
+  <a class="gem-c-button govuk-button gem-c-button--secondary gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/help/cookies">Cookie settings</a>
+
+
+      </div>
+    </div>
+  </div>
+
+  <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
+    <p class="gem-c-cookie-banner__confirmation-message">
+      You’ve accepted all cookies. You can <a class="govuk-link" href="/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.
+    </p>
+    <button class="gem-c-cookie-banner__hide-button" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
+  </div>
+</div>
+
+
+    <header role="banner" id="global-header" class=" with-proposition">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" id="logo" class="content" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
+              <img src="https://assets.publishing.service.gov.uk/static/gov.uk_logotype_crown_invert_trans-203e1db49d3eff430d7dc450ce723c1002542fe1d2bce661b6d8571f14c1043c.png" width="36" height="32" alt=""> GOV.UK
+            </a>
+          </div>
+            <a href="#search" class="search-toggle js-header-toggle">Search</a>
+  <form id="search" class="site-search" action="/search" method="get" role="search">
+    <div class="content">
+      <label for="site-search-text">Search</label>
+      <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
+      <input class="submit" type="submit" value="Search">
+    </div>
+  </form>
+
+        </div>
+        
+      <div class="header-proposition">
+  <div class="content">
+    <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+  <nav id="proposition-menu" class="no-proposition-name gem-c-government-navigation">
+  <ul id="proposition-links">
+    <li>
+      <a class="" href="/government/organisations">
+        Departments
+      </a>
+    </li>
+    <li>
+      <a class="" href="/government/world">
+        Worldwide
+      </a>
+    </li>
+    <li>
+      <a class="" href="/government/how-government-works">
+        How government works
+      </a>
+    </li>
+    <li>
+      <a class="" href="/government/get-involved">
+        Get involved
+      </a>
+    </li>
+    <li class="clear-child">
+      <a class="" href="/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&amp;amp;content_store_document_type%5B%5D=closed_consultations">
+        Consultations
+      </a>
+    </li>
+    <li>
+      <a class="" href="/search/research-and-statistics">
+        Statistics
+      </a>
+    </li>
+    <li>
+      <a class="" href="/news-and-communications">
+        News and communications
+      </a>
+    </li>
+  </ul>
+</nav>
+</div>
+</div>
+</div>
+    </header>
+
+      <div id="user-satisfaction-survey-container"></div>
+
+
+    <div id="global-header-bar"></div>
+
+      
+  <!--[if gt IE 7]><!-->
+  <div id="global-bar" class="global-bar dont-print" data-module="global-bar">
+    <div class="global-bar-message-container">
+    <p class="global-bar-message">
+          <a class="global-bar-title govuk-link js-call-to-action" href="/register-to-vote">Register to vote</a>
+
+          <span>Register by 26 November to vote in the General Election on 12 December.</span>
+    </p>
+    <a href="#hide-message" class="govuk-link dismiss" role="button" aria-controls="global-bar">Hide message</a>
+    </div>
+  </div>
+  <!--<![endif]-->
+
+
+  <div id="wrapper" class="direction-ltr">
+    
+
+      
+<div class="gem-c-contextual-breadcrumbs">
+    
+
+
+<div class="gem-c-breadcrumbs govuk-breadcrumbs " data-module="track-click">
+  <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item" aria-current="false">
+          <a data-track-category="homeLinkClicked" data-track-action="homeBreadcrumb" data-track-label="" data-track-options="{}" class="govuk-breadcrumbs__link" aria-current="false" href="/">Home</a>
+      </li>
+  </ol>
+</div>
+
+
+</div>
+
+
+    <main role="main" id="content" class="publication" lang="en">
+      
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="gem-c-title govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+    <p class="gem-c-title__context">
+      Research and analysis
+    </p>
+  <h1 class="gem-c-title__text gem-c-title__text--long">
+    Public mental health leadership and workforce development framework
+  </h1>
+</div>
+  </div>
+  
+
+  <div class="govuk-grid-column-two-thirds">
+    
+  <p class="gem-c-lead-paragraph">This framework can inform and influence the development of public health leadership and the workforce in relation to mental health.</p>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="metadata-logo-wrapper">
+    <div class="govuk-grid-column-two-thirds metadata-column">
+        <div class="app-c-publisher-metadata" lang="en">
+    <div class="app-c-published-dates " lang="en">
+    Published 10 March 2015
+    <br>Last updated 29 August 2018
+      — <a href="#history" class="app-c-published-dates__history-link govuk-link">see all updates</a>
+</div>
+
+      <div class="app-c-publisher-metadata__other">
+        <dl data-module="track-click">
+            <dt class="app-c-publisher-metadata__term">
+              From:
+            </dt>
+            <dd class="app-c-publisher-metadata__definition" data-module="gem-toggle">
+                <span class="app-c-publisher-metadata__definition-sentence">
+                  <a class="govuk-link" href="/government/organisations/public-health-england">Public Health England</a>
+                </span>
+            </dd>
+        </dl>
+      </div>
+  </div>
+
+    </div>
+    <div class="govuk-grid-column-one-third">
+    </div>
+  </div>
+</div>
+
+
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds responsive-bottom-margin">
+    
+    <div class="responsive-bottom-margin">
+       <h2 class="gem-c-heading  gem-c-heading--mobile-top-margin  " id="documents-title">Documents</h2>
+
+
+<div aria-labelledby="documents-title">
+  
+<div class="gem-c-govspeak govuk-govspeak direction-ltr" data-module="govspeak">
+      <section class="attachment embedded" id="attachment_3193462">
+  <div class="attachment-thumb">
+      <a aria-hidden="true" class="thumbnail" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736580/Mental_health_promotion_and_prevention_training_programmes.pdf"><img alt="" src="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736580/thumbnail_Mental_health_promotion_and_prevention_training_programmes.pdf.png"></a>
+  </div>
+  <div class="attachment-details">
+    <h2 class="title"><a aria-describedby="attachment-3193462-accessibility-help" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736580/Mental_health_promotion_and_prevention_training_programmes.pdf">Public mental health promotion and prevention training programmes</a></h2>
+    <p class="metadata">
+        <span class="references">
+          Ref: <span class="unique_reference">PHE publications gateway number 2016283</span>
+        </span>
+        <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">767KB</span>, <span class="page-length">55 pages</span>
+    </p>
+
+
+      <div data-module="toggle" class="accessibility-warning" id="attachment-3193462-accessibility-help">
+        <h2>This file may not be suitable for users of assistive technology.
+          <a class="toggler" href="#attachment-3193462-accessibility-request" data-controls="attachment-3193462-accessibility-request" data-expanded="false">Request an accessible format.</a>
+        </h2>
+        <p id="attachment-3193462-accessibility-request" class="js-hidden">
+          If you use assistive technology (such as a screen reader) and need a
+version of this document in a more accessible format, please email <a href="mailto:publications@phe.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Public%20mental%20health%20promotion%20and%20prevention%20training%20programmes%0A%20%20Original%20format%3A%20pdf%0A%20%20Unique%20reference%3A%20PHE%20publications%20gateway%20number%202016283%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Public%20mental%20health%20promotion%20and%20prevention%20training%20programmes%27%20in%20an%20alternative%20format">publications@phe.gov.uk</a>.
+Please tell us what format you need. It will help us if you say what assistive technology you use.
+
+        </p>
+      </div>
+  </div>
+</section><section class="attachment embedded" id="attachment_3193463">
+  <div class="attachment-thumb">
+      <a aria-hidden="true" class="thumbnail" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736587/Public_mental_health_leadership_and_workforce_development_framework_executive_summary.pdf"><img alt="" src="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736587/thumbnail_Public_mental_health_leadership_and_workforce_development_framework_executive_summary.pdf.png"></a>
+  </div>
+  <div class="attachment-details">
+    <h2 class="title"><a aria-describedby="attachment-3193463-accessibility-help" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736587/Public_mental_health_leadership_and_workforce_development_framework_executive_summary.pdf">Public mental health leadership and workforce development framework: executive summary</a></h2>
+    <p class="metadata">
+        <span class="references">
+          Ref: <span class="unique_reference">PHE publications gateway number 2014789</span>
+        </span>
+        <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">236KB</span>, <span class="page-length">6 pages</span>
+    </p>
+
+
+      <div data-module="toggle" class="accessibility-warning" id="attachment-3193463-accessibility-help">
+        <h2>This file may not be suitable for users of assistive technology.
+          <a class="toggler" href="#attachment-3193463-accessibility-request" data-controls="attachment-3193463-accessibility-request" data-expanded="false">Request an accessible format.</a>
+        </h2>
+        <p id="attachment-3193463-accessibility-request" class="js-hidden">
+          If you use assistive technology (such as a screen reader) and need a
+version of this document in a more accessible format, please email <a href="mailto:publications@phe.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%3A%20executive%20summary%0A%20%20Original%20format%3A%20pdf%0A%20%20Unique%20reference%3A%20PHE%20publications%20gateway%20number%202014789%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%3A%20executive%20summary%27%20in%20an%20alternative%20format">publications@phe.gov.uk</a>.
+Please tell us what format you need. It will help us if you say what assistive technology you use.
+
+        </p>
+      </div>
+  </div>
+</section><section class="attachment embedded" id="attachment_3193464">
+  <div class="attachment-thumb">
+      <a aria-hidden="true" class="thumbnail" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736582/Call_to_Action_3.pdf"><img alt="" src="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736582/thumbnail_Call_to_Action_3.pdf.png"></a>
+  </div>
+  <div class="attachment-details">
+    <h2 class="title"><a aria-describedby="attachment-3193464-accessibility-help" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736582/Call_to_Action_3.pdf">Public mental health leadership and workforce development framework: call to action</a></h2>
+    <p class="metadata">
+        <span class="references">
+          Ref: <span class="unique_reference">PHE publications gateway number 2018380</span>
+        </span>
+        <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">460KB</span>, <span class="page-length">10 pages</span>
+    </p>
+
+
+      <div data-module="toggle" class="accessibility-warning" id="attachment-3193464-accessibility-help">
+        <h2>This file may not be suitable for users of assistive technology.
+          <a class="toggler" href="#attachment-3193464-accessibility-request" data-controls="attachment-3193464-accessibility-request" data-expanded="false">Request an accessible format.</a>
+        </h2>
+        <p id="attachment-3193464-accessibility-request" class="js-hidden">
+          If you use assistive technology (such as a screen reader) and need a
+version of this document in a more accessible format, please email <a href="mailto:publications@phe.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%3A%20call%20to%20action%0A%20%20Original%20format%3A%20pdf%0A%20%20Unique%20reference%3A%20PHE%20publications%20gateway%20number%202018380%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%3A%20call%20to%20action%27%20in%20an%20alternative%20format">publications@phe.gov.uk</a>.
+Please tell us what format you need. It will help us if you say what assistive technology you use.
+
+        </p>
+      </div>
+  </div>
+</section><section class="attachment embedded" id="attachment_3193465">
+  <div class="attachment-thumb">
+      <a aria-hidden="true" class="thumbnail" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736583/Public_Mental_Health_Leadership_and_Workforce_Development_Framework.pdf"><img alt="" src="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736583/thumbnail_Public_Mental_Health_Leadership_and_Workforce_Development_Framework.pdf.png"></a>
+  </div>
+  <div class="attachment-details">
+    <h2 class="title"><a aria-describedby="attachment-3193465-accessibility-help" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736583/Public_Mental_Health_Leadership_and_Workforce_Development_Framework.pdf">Public mental health leadership and workforce development framework</a></h2>
+    <p class="metadata">
+        <span class="references">
+          Ref: <span class="unique_reference">PHE publications gateway number 2014789</span>
+        </span>
+        <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">1.42MB</span>, <span class="page-length">35 pages</span>
+    </p>
+
+
+      <div data-module="toggle" class="accessibility-warning" id="attachment-3193465-accessibility-help">
+        <h2>This file may not be suitable for users of assistive technology.
+          <a class="toggler" href="#attachment-3193465-accessibility-request" data-controls="attachment-3193465-accessibility-request" data-expanded="false">Request an accessible format.</a>
+        </h2>
+        <p id="attachment-3193465-accessibility-request" class="js-hidden">
+          If you use assistive technology (such as a screen reader) and need a
+version of this document in a more accessible format, please email <a href="mailto:publications@phe.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%0A%20%20Original%20format%3A%20pdf%0A%20%20Unique%20reference%3A%20PHE%20publications%20gateway%20number%202014789%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%27%20in%20an%20alternative%20format">publications@phe.gov.uk</a>.
+Please tell us what format you need. It will help us if you say what assistive technology you use.
+
+        </p>
+      </div>
+  </div>
+</section><section class="attachment embedded" id="attachment_3193466">
+  <div class="attachment-thumb">
+      <a aria-hidden="true" class="thumbnail" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736586/Public_mental_health_leadership_and_workforce_development_framework_appendices.pdf"><img alt="" src="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736586/thumbnail_Public_mental_health_leadership_and_workforce_development_framework_appendices.pdf.png"></a>
+  </div>
+  <div class="attachment-details">
+    <h2 class="title"><a aria-describedby="attachment-3193466-accessibility-help" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/736586/Public_mental_health_leadership_and_workforce_development_framework_appendices.pdf">Public mental health leadership and workforce development framework: appendices</a></h2>
+    <p class="metadata">
+        <span class="references">
+          Ref: <span class="unique_reference">PHE publications gateway number 2014789</span>
+        </span>
+        <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">328KB</span>, <span class="page-length">17 pages</span>
+    </p>
+
+
+      <div data-module="toggle" class="accessibility-warning" id="attachment-3193466-accessibility-help">
+        <h2>This file may not be suitable for users of assistive technology.
+          <a class="toggler" href="#attachment-3193466-accessibility-request" data-controls="attachment-3193466-accessibility-request" data-expanded="false">Request an accessible format.</a>
+        </h2>
+        <p id="attachment-3193466-accessibility-request" class="js-hidden">
+          If you use assistive technology (such as a screen reader) and need a
+version of this document in a more accessible format, please email <a href="mailto:publications@phe.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%3A%20appendices%0A%20%20Original%20format%3A%20pdf%0A%20%20Unique%20reference%3A%20PHE%20publications%20gateway%20number%202014789%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Public%20mental%20health%20leadership%20and%20workforce%20development%20framework%3A%20appendices%27%20in%20an%20alternative%20format">publications@phe.gov.uk</a>.
+Please tell us what format you need. It will help us if you say what assistive technology you use.
+
+        </p>
+      </div>
+  </div>
+</section>
+</div>
+
+</div>
+
+<h2 class="gem-c-heading  gem-c-heading--mobile-top-margin  " id="details-title">Details</h2>
+
+
+<div aria-labelledby="details-title">
+  
+<div class="gem-c-govspeak govuk-govspeak direction-ltr" data-module="govspeak">
+      <div class="govspeak">
+<p>This framework includes:</p>
+
+<ul>
+  <li>executive summary</li>
+  <li>call to action</li>
+  <li>framework</li>
+  <li>appendices</li>
+</ul>
+</div>
+</div>
+
+</div>
+
+    </div>
+
+    <div class="app-c-published-dates app-c-published-dates--history" id="history" data-module="toggle" lang="en">
+    Published 10 March 2015
+    <br>Last updated 29 August 2018
+      <a href="#full-history" class="app-c-published-dates__toggle govuk-link" data-controls="full-history" data-expanded="false" data-toggled-text="- hide all updates">+ show all updates</a>
+      <div class="app-c-published-dates__change-history js-hidden" id="full-history">
+        <ol>
+            <li class="app-c-published-dates__change-item">
+              <time class="app-c-published-dates__change-date timestamp" datetime="2018-08-29T10:36:55.000+01:00">29 August 2018</time>
+              Updated: 'Public mental health leadership and workforce development framework: Call to action'
+            </li>
+            <li class="app-c-published-dates__change-item">
+              <time class="app-c-published-dates__change-date timestamp" datetime="2016-09-22T14:54:10.000+01:00">22 September 2016</time>
+              Uploaded promotion and prevention training programmes PDF.
+            </li>
+            <li class="app-c-published-dates__change-item">
+              <time class="app-c-published-dates__change-date timestamp" datetime="2015-03-10T00:15:00.000+00:00">10 March 2015</time>
+              First published.
+            </li>
+        </ol>
+      </div>
+</div>
+
+  </div>
+  
+<div class="govuk-grid-column-one-third">
+  
+<div class="gem-c-contextual-sidebar">
+
+
+    
+  <div class="gem-c-related-navigation">
+
+      <h2 id="related-nav-related_items-696523df" class="gem-c-related-navigation__main-heading" data-track-count="sidebarRelatedItemSection">
+        Related content
+      </h2>
+
+
+
+
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-696523df" data-module="gem-toggle">
+
+
+  <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+
+
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.1 Related content" data-track-label="/government/publications/prevention-concordat-for-better-mental-health-consensus-statement" data-track-options='{"dimension28":"5","dimension29":"Prevention concordat for better mental health: consensus statement"}' href="/government/publications/prevention-concordat-for-better-mental-health-consensus-statement">Prevention concordat for better mental health: consensus statement</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.2 Related content" data-track-label="/government/publications/stocktake-of-local-mental-health-prevention-planning-arrangements" data-track-options='{"dimension28":"5","dimension29":"Stocktake of local mental health prevention planning arrangements"}' href="/government/publications/stocktake-of-local-mental-health-prevention-planning-arrangements">Stocktake of local mental health prevention planning arrangements</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.3 Related content" data-track-label="/government/publications/health-and-wellbeing-a-guide-to-community-centred-approaches" data-track-options='{"dimension28":"5","dimension29":"Health and wellbeing: a guide to community-centred approaches"}' href="/government/publications/health-and-wellbeing-a-guide-to-community-centred-approaches">Health and wellbeing: a guide to community-centred approaches</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.4 Related content" data-track-label="/government/publications/psychosocial-pathways-and-health-outcomes" data-track-options='{"dimension28":"5","dimension29":"Psychosocial pathways and health outcomes"}' href="/government/publications/psychosocial-pathways-and-health-outcomes">Psychosocial pathways and health outcomes</a></li>
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar gem-c-related-navigation__section-link--inline  gem-c-related-navigation__section-link--other" data-track-category="relatedLinkClicked" data-track-action="1.5 Related content" data-track-label="/government/publications/prevention-concordat-for-better-mental-health-planning-resource" data-track-options='{"dimension28":"5","dimension29":"Prevention concordat for better mental health: planning resource"}' href="/government/publications/prevention-concordat-for-better-mental-health-planning-resource">Prevention concordat for better mental health: planning resource</a></li>
+
+  </ul>
+</nav>
+
+
+
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-collections-696523df" data-module="gem-toggle">
+
+    <h3 id="related-nav-collections-696523df" class="gem-c-related-navigation__sub-heading gem-c-related-navigation__sub-heading--sidebar" data-track-count="sidebarRelatedItemSection">Collection</h3>
+
+  <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+
+
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--sidebar" data-track-category="relatedLinkClicked" data-track-action="2.1 Collection" data-track-label="/government/collections/public-mental-health" data-track-options='{"dimension28":"1","dimension29":"Public mental health"}' href="/government/collections/public-mental-health">Public mental health</a></li>
+
+  </ul>
+</nav>
+
+  </div>
+
+
+
+</div>
+
+</div>
+
+</div>
+
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        
+  <div class="gem-c-contextual-footer">
+    
+  <div class="gem-c-related-navigation">
+
+
+
+
+
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-topics-89d259c4" data-module="gem-toggle">
+
+    <h2 id="related-nav-topics-89d259c4" class="gem-c-related-navigation__sub-heading gem-c-related-navigation__sub-heading--footer" data-track-count="footerRelatedItemSection">Explore the topic</h2>
+
+  <ul class="gem-c-related-navigation__link-list" data-module="track-click">
+
+
+        <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--footer" data-track-category="relatedLinkClicked" data-track-action="1.1 Explore the topic" data-track-label="/health-and-social-care/mental-health" data-track-options='{"dimension28":"1","dimension29":"Mental health"}' href="/health-and-social-care/mental-health">Mental health</a></li>
+
+  </ul>
+</nav>
+
+  </div>
+
+  </div>
+
+
+    </div>
+  </div>
+
+
+    </main>
+    
+<div class="gem-c-feedback gem-c-feedback--top-margin" data-module="feedback">
+  
+<div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
+  <div class="gem-c-feedback__js-prompt-questions js-prompt-questions">
+    <h2 class="gem-c-feedback__prompt-question">Is this page useful?</h2>
+
+    <a class="gem-c-feedback__prompt-link" data-track-category="yesNoFeedbackForm" data-track-action="ffMaybeClick" aria-expanded="false" role="button" style="display: none;" hidden="hidden" aria-hidden="true" href="/contact/govuk">
+      Maybe
+</a>
+    <a class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick" aria-expanded="false" role="button" href="/contact/govuk">
+      Yes <span class="visually-hidden">this page is useful</span>
+</a>
+    <a class="gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false" role="button" href="/contact/govuk">
+      No <span class="visually-hidden">this page is not useful</span>
+</a>
+    <a class="gem-c-feedback__prompt-link gem-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV.UK Open Form" aria-controls="something-is-wrong" aria-expanded="false" role="button" href="/contact/govuk">
+      Is there anything wrong with this page?
+</a>  </div>
+
+  <div class="gem-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
+    Thank you for your feedback
+  </div>
+</div>
+
+  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="gem-c-feedback__form js-feedback-form js-hidden" data-track-category="Onsite Feedback" data-track-action="GOV.UK Send Form" method="post">
+  <a href="#" class="gem-c-feedback__close gem-c-feedback__js-show js-close-form" data-track-category="Onsite Feedback" data-track-action="GOV.UK Close Form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="gem-c-feedback__error-summary gem-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
+
+      <input type="hidden" name="url" value="https://www.gov.uk/government/publications/public-mental-health-leadership-and-workforce-development-framework">
+
+      <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
+      <p id="feedback_explanation" class="gem-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>
+
+      
+<div class="govuk-form-group">
+    
+<label for="input-019368e2" class="gem-c-label govuk-label">
+  What were you doing?
+</label>
+
+
+
+
+  <input name="what_doing" class="gem-c-input govuk-input" id="input-019368e2" type="text" aria-describedby="feedback_explanation">
+</div>
+
+      
+<div class="govuk-form-group">
+    
+<label for="input-b6951003" class="gem-c-label govuk-label">
+  What went wrong?
+</label>
+
+
+
+
+  <input name="what_wrong" class="gem-c-input govuk-input" id="input-b6951003" type="text">
+</div>
+
+      
+
+
+  <button class="gem-c-button govuk-button" type="submit">Send</button>
+
+
+    </div>
+  </div>
+</form>
+
+  <form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="gem-c-feedback__form gem-c-feedback__form--email gem-c-feedback__js-show js-feedback-form js-hidden" data-track-category="yesNoFeedbackForm" data-track-action="Send Form" method="post">
+  <a href="#" class="gem-c-feedback__close js-close-form" data-track-category="yesNoFeedbackForm" data-track-action="ffFormClose" aria-controls="page-is-not-useful" aria-expanded="true" role="button">Close</a>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds" id="survey-wrapper">
+      <div class="gem-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
+
+      <input name="email_survey_signup[survey_id]" type="hidden" value="footer_satisfaction_survey">
+      <input name="email_survey_signup[survey_source]" type="hidden" value="/government/publications/public-mental-health-leadership-and-workforce-development-framework">
+
+      <h3 class="gem-c-feedback__form-heading">Help us improve GOV.UK</h3>
+      <p id="survey_explanation" class="gem-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>
+
+      
+<div class="govuk-form-group">
+    
+<label for="input-12471430" class="gem-c-label govuk-label">
+  Email address
+</label>
+
+
+
+
+  <input name="email_survey_signup[email_address]" class="gem-c-input govuk-input" id="input-12471430" type="email" autocomplete="email" aria-describedby="survey_explanation">
+</div>
+
+      
+
+
+  <button class="gem-c-button govuk-button" type="submit">Send me the survey</button>
+
+
+    </div>
+  </div>
+</form>
+
+</div>
+
+  </div>
+
+    <div id="global-app-error" class="app-error hidden"></div>
+</body>
+</html>
+

--- a/reach/scraper/tests/test_gov_spider.py
+++ b/reach/scraper/tests/test_gov_spider.py
@@ -44,9 +44,9 @@ class TestGovSpider(unittest.TestCase):
             'content-type': b'application/pdf'
         }
 
-        request = Request('http://foo.bar', meta=meta)
+        request = Request('http://foo.bar/documents/document.pdf', meta=meta)
         pdf_response = Response(
-            'http://foo.bar',
+            'http://foo.bar/documents/document.pdf',
             body=self.test_file.read(),
             request=request,
             headers=headers
@@ -84,7 +84,7 @@ class TestGovSpider(unittest.TestCase):
         parse_article function.
         """
 
-        with open(get_path('mock_sites/gov/2.html'), 'rb') as html_site:
+        with open(get_path('mock_sites/gov/3.html'), 'rb') as html_site:
             request = Request('http://foo.bar')
             response = HtmlResponse(
                 'http://foo.bar',

--- a/reach/scraper/tests/test_msf_spider.py
+++ b/reach/scraper/tests/test_msf_spider.py
@@ -43,9 +43,9 @@ class TestMsfSpider(unittest.TestCase):
             'content-type': b'application/pdf'
         }
 
-        request = Request('http://foo.bar', meta=meta)
+        request = Request('http://foo.bar/documents/document.pdf', meta=meta)
         pdf_response = Response(
-            'http://foo.bar',
+            'http://foo.bar/documents/document.pdf',
             body=self.test_file.read(),
             request=request,
             headers=headers

--- a/reach/scraper/tests/test_nice_spider.py
+++ b/reach/scraper/tests/test_nice_spider.py
@@ -46,9 +46,9 @@ class TestNiceSpider(unittest.TestCase):
             'content-type': b'application/pdf'
         }
 
-        request = Request('http://foo.bar', meta=meta)
+        request = Request('http://foo.bar/documents/document.pdf', meta=meta)
         pdf_response = Response(
-            'http://foo.bar',
+            'http://foo.bar/documents/document.pdf',
             body=self.test_file.read(),
             request=request,
             headers=headers

--- a/reach/scraper/tests/test_parliament_spider.py
+++ b/reach/scraper/tests/test_parliament_spider.py
@@ -43,9 +43,9 @@ class TestParliamentSpider(unittest.TestCase):
             'content-type': b'application/pdf'
         }
 
-        request = Request('http://foo.bar', meta=meta)
+        request = Request('http://foo.bar/documents/document.pdf', meta=meta)
         pdf_response = Response(
-            'http://foo.bar',
+            'http://foo.bar/documents/document.pdf',
             body=self.test_file.read(),
             request=request,
             headers=headers

--- a/reach/scraper/tests/test_scraper_spiders.py
+++ b/reach/scraper/tests/test_scraper_spiders.py
@@ -31,9 +31,9 @@ class TestBaseSpider(unittest.TestCase):
         headers = {
             'content-type': b'application/pdf'
         }
-        request = Request('http://foo.bar', meta=meta)
+        request = Request('http://foo.bar/documents/document.pdf', meta=meta)
         self.pdf_response = Response(
-            'http://foo.bar',
+            'http://foo.bar/documents/document.pdf',
             body=self.test_file.read(),
             request=request,
             headers=headers

--- a/reach/scraper/tests/test_unicef_spider.py
+++ b/reach/scraper/tests/test_unicef_spider.py
@@ -43,9 +43,9 @@ class TestUnicefSpider(unittest.TestCase):
             'content-type': b'application/pdf'
         }
 
-        request = Request('http://foo.bar', meta=meta)
+        request = Request('http://foo.bar/documents/document.pdf', meta=meta)
         pdf_response = Response(
-            'http://foo.bar',
+            'http://foo.bar/documents/document.pdf',
             body=self.test_file.read(),
             request=request,
             headers=headers

--- a/reach/scraper/tests/test_who_spider.py
+++ b/reach/scraper/tests/test_who_spider.py
@@ -45,9 +45,9 @@ class TestWhoIrisSpider(unittest.TestCase):
             'content-type': b'application/pdf'
         }
 
-        request = Request('http://foo.bar', meta=meta)
+        request = Request('http://foo.bar/documents/document.pdf', meta=meta)
         pdf_response = Response(
-            'http://foo.bar',
+            'http://foo.bar/documents/document.pdf',
             body=self.test_file.read(),
             request=request,
             headers=headers

--- a/reach/scraper/wsf_scraping/spiders/base_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/base_spider.py
@@ -107,7 +107,7 @@ class BaseSpider(scrapy.Spider):
         except ValueError: # For example invalid IPV6 URL or something
             return False
 
-        if scheme != '' and scheme not in VALID_SCHEMES:
+        if scheme != '' and scheme not in self.schemes:
             return False
 
         if not path.lower().endswith(".%s" % extension.lower()):

--- a/reach/scraper/wsf_scraping/spiders/gov_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/gov_spider.py
@@ -75,11 +75,8 @@ class GovSpider(BaseSpider):
             '.attachment-details h2 a::attr("href")'
         ).extract()
 
-        print("LINKS", document_links)
-
         for fhref in document_links:
             title = response.css('h1::text').extract_first().strip('\n ')
-            print(fhref)
             if self._is_valid_pdf_url(fhref):
                 yield Request(
                     url=response.urljoin(fhref),

--- a/reach/scraper/wsf_scraping/spiders/gov_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/gov_spider.py
@@ -75,13 +75,17 @@ class GovSpider(BaseSpider):
             '.attachment-details h2 a::attr("href")'
         ).extract()
 
+        print("LINKS", document_links)
+
         for fhref in document_links:
             title = response.css('h1::text').extract_first().strip('\n ')
-            yield Request(
-                url=response.urljoin(fhref),
-                callback=self.save_pdf,
-                errback=self.on_error,
-                meta={'title': title}
-            )
+            print(fhref)
+            if self._is_valid_pdf_url(fhref):
+                yield Request(
+                    url=response.urljoin(fhref),
+                    callback=self.save_pdf,
+                    errback=self.on_error,
+                    meta={'title': title}
+                )
 
 

--- a/reach/scraper/wsf_scraping/spiders/msf_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/msf_spider.py
@@ -36,8 +36,9 @@ class MsfSpider(BaseSpider):
 
         doc_links = response.css('.field-items a::attr(href)').extract()
         for url in doc_links:
-            yield scrapy.Request(
-                url=response.urljoin(url),
-                errback=self.on_error,
-                callback=self.save_pdf
-            )
+            if self._is_valid_pdf_url(url):
+                yield scrapy.Request(
+                    url=response.urljoin(url),
+                    errback=self.on_error,
+                    callback=self.save_pdf
+                )

--- a/reach/scraper/wsf_scraping/spiders/parliament_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/parliament_spider.py
@@ -86,12 +86,7 @@ class ParliamentSpider(BaseSpider):
         at this point, we stop looking this way.
         """
 
-        # Some of the parliament's pdf are categorised as octetstream,
-        # so we pass multiple mimetypes that the file could be
-        if self._is_valid_pdf(
-                response,
-                mimetype=(b'application/octet-stream', b'application/pdf',)
-            ):
+        if self._is_valid_pdf(response):
             yield Request(
                 url=response.urljoin(response.request.url),
                 meta={
@@ -107,9 +102,10 @@ class ParliamentSpider(BaseSpider):
             b'text/html',
         ):
             for href in response.css('a::attr(href)').extract():
-                if self._is_valid_pdf_url(href):
+                url = response.urljoin(href)
+                if self._is_valid_pdf_url(url):
                     yield Request(
-                        url=response.urljoin(href),
+                        url=url,
                         meta={
                             'title': response.meta.get('title'),
                             'year': response.meta.get('year'),

--- a/reach/scraper/wsf_scraping/spiders/unicef_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/unicef_spider.py
@@ -54,7 +54,7 @@ class UnicefSpider(BaseSpider):
 
         title = response.css('.entry-heading h1::text').extract_first()
         hrefs = response.css('a::attr("href")').extract()
-        ls = list(filter(lambda x: x.endswith('pdf'), hrefs))
+        ls = list(filter(lambda x: self._is_valid_pdf_url(x), hrefs))
         for link in ls:
             yield Request(
                 url=response.urljoin(link),

--- a/reach/scraper/wsf_scraping/spiders/who_iris_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/who_iris_spider.py
@@ -122,7 +122,7 @@ class WhoIrisSpider(BaseSpider):
         data_dict['authors'] = ', '.join(
             details_dict.get('contributor author', [])
         )
-        if href:
+        if self._is_valid_pdf_url(href):
             yield Request(
                 url=response.urljoin(href),
                 callback=self.save_pdf,


### PR DESCRIPTION
# Description

This pull is to fix #261 see that issue for the specific details of the issue.

* Adds new `_is_valid_pdf` and `_is_valid_pdf_url` methods to `base_spider.py` which filter on headers as well as the URL fragment for selecting appropriate PDF files for download.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix

# How Has This Been Tested?

`make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
