### PR TITLE
spider: Adding a new additional middleware Fix #275

### DIFF
--- a/reach/scraper/wsf_scraping/settings.py
+++ b/reach/scraper/wsf_scraping/settings.py
@@ -23,7 +23,7 @@ FEED_STORAGES = {
 }
 
 SPIDER_MIDDLEWARES = {
-    'reach.scraper.wsf_scraping.middlewares.ReachOffsiteMiddleware': 450,
+    'reach.scraper.wsf_scraping.middlewares.ReachDisallowedHostMiddleware': 450,
 }
 
 LOG_LEVEL = 'INFO'

--- a/reach/scraper/wsf_scraping/settings.py
+++ b/reach/scraper/wsf_scraping/settings.py
@@ -22,6 +22,10 @@ FEED_STORAGES = {
     'local': 'reach.scraper.wsf_scraping.feed_storage.ManifestFeedStorage',
 }
 
+SPIDER_MIDDLEWARES = {
+    'reach.scraper.wsf_scraping.middlewares.ReachOffsiteMiddleware': 450,
+}
+
 LOG_LEVEL = 'INFO'
 LOG_FORMATTER = 'reach.scraper.wsf_scraping.middlewares.PoliteLogFormatter'
 

--- a/reach/scraper/wsf_scraping/spiders/gov_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/gov_spider.py
@@ -12,6 +12,10 @@ class GovSpider(BaseSpider):
         'JOBDIR': BaseSpider.jobdir(name)
     }
 
+    disallowed_domains = [
+        'beta.hfea.gov.uk', # Site no longer exists but gov links off to it
+    ]
+
     def __init__(self, **kwargs):
         """Initialise the class attribute year_before and year_after. The
         attribute year_before excludes everything from said year.

--- a/reach/scraper/wsf_scraping/spiders/gov_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/gov_spider.py
@@ -12,7 +12,7 @@ class GovSpider(BaseSpider):
         'JOBDIR': BaseSpider.jobdir(name)
     }
 
-    disallowed_domains = [
+    disallowed_hosts = [
         'beta.hfea.gov.uk', # Site no longer exists but gov links off to it
     ]
 


### PR DESCRIPTION


# Description

New middleware which allows specifying  parameter in spider subclasses
which allows blocking of crawls to sites which are known to cause issues (i.e. beta.hfea.gov.uk)
from the gov scraper.

## Type of change

- [x] :bug: Bug fix

# How Has This Been Tested?

`make docker-test`

Running policy-test DAG with `disallowed_hosts` set to known domains that show up in the policy-test crawl for a given spider (i.e. for the gov scraper disallowing crawls on gov.uk)

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
