### PR TITLE
reach/web: disable search engine indexing

### DIFF
--- a/reach/web/api.py
+++ b/reach/web/api.py
@@ -14,7 +14,9 @@ import falcon
 from elasticsearch import Elasticsearch
 
 from reach.sentry import report_exception
-from reach.web.views import template, search
+from reach.web.views import template
+from reach.web.views import search
+from reach.web.views import robotstxt
 
 TEMPLATE_ROOT = os.path.join(os.path.dirname(__file__), 'templates')
 
@@ -67,6 +69,7 @@ def create_api(conf):
         '/',
         template.TemplateResource(TEMPLATE_ROOT, get_context(os.environ))
     )
+    api.add_route('/robots.txt', robotstxt.RobotsTxtResource())
     api.add_route(
         '/search/citations',
         search.CitationPage(

--- a/reach/web/views/robotstxt.py
+++ b/reach/web/views/robotstxt.py
@@ -1,0 +1,12 @@
+""" Serve GET /robots.txt. """
+
+# Disable all indexing until beta.
+ROBOTS_TXT = \
+"""User-agent: *
+Disallow: /
+"""
+
+class RobotsTxtResource(object):
+    def on_get(self, req, resp):
+        resp.body = ROBOTS_TXT
+        resp.content_type = 'text/plain'


### PR DESCRIPTION
# Description

Extend reach/web/api.py so that it serves GET /robots.txt requests.

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?


```
curl http://localhost:8081/robots.txt
make docker-test
```

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
