### PR TITLE
Add sorting and pagination to the tables

### DIFF
--- a/reach/web/.dockerignore
+++ b/reach/web/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/reach/web/package.json
+++ b/reach/web/package.json
@@ -17,6 +17,7 @@
     "gulp-postcss": "^8.0.0",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.2",
+    "list.js": "^1.5.0",
     "postcss": "^7.0.21",
     "postcss-import": "^12.0.1",
     "postcss-url": "^8.0.0",

--- a/reach/web/src/css/results.css
+++ b/reach/web/src/css/results.css
@@ -14,3 +14,39 @@
 .pagination .page-item.active a {
 	background-color: $cyanPrimary;
 }
+
+.pagination {
+	float: right;
+
+	li a {
+		padding: 0.3rem;
+		text-decoration: none;
+	}
+
+	li.active a {
+		background-color: $cyanPrimary;
+		color: white;
+	}
+}
+
+th {
+  font-family: "Helvetica Neue";
+  font-size: 0.75rem;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  text-transform: uppercase;
+  line-height: 1.5;
+  letter-spacing: 0.5px;
+  color: $greyLink;
+}
+
+#citations-result-table th:first-child::before {
+	content: url(../images/Icon_Research_24px.svg);
+	margin-right: 10px;
+}
+
+th::after {
+	content: url(../images/Icon_Sort-by_16px.svg);
+	margin-left: 10px;
+}

--- a/reach/web/src/images/Icon_Research_24px.svg
+++ b/reach/web/src/images/Icon_Research_24px.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="24px" height="24px" viewBox="0 -5 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 59.1 (86144) - https://sketch.com -->
     <title>Icon_Research_24px</title>
     <desc>Created with Sketch.</desc>

--- a/reach/web/src/js/app.js
+++ b/reach/web/src/js/app.js
@@ -1,5 +1,7 @@
 import clearSearch from './clearSearch.js';
+import sortTables from './sortTables.js';
 
 document.addEventListener('DOMContentLoaded', function(event) {
   clearSearch();
+  sortTables();
 });

--- a/reach/web/src/js/sortTables.js
+++ b/reach/web/src/js/sortTables.js
@@ -1,4 +1,5 @@
 const List = require('list.js');
+const ItemsPerPage = 25;
 
 function updateCount(htmlItem) {
     let current = 1;
@@ -15,9 +16,13 @@ function updateCount(htmlItem) {
     if (htmlItem && htmlItem.innerText) {
         current = parseInt(htmlItem.innerText);
     }
+    let maxResults = ItemsPerPage + (current - 1) * ItemsPerPage;
 
-    let maxResults = (maxEsResults < 25 || (25 + (current - 1) * 25) > maxEsResults)? maxEsResults : 25 + (current - 1) * 25;
-    let resultsTemplate = `${1 + (current - 1) * 25} - ${maxResults} of `;
+    if (maxEsResults < ItemsPerPage || (ItemsPerPage + (current - 1) * ItemsPerPage) > maxEsResults) {
+    	maxResults = maxEsResults;
+    }
+
+    let resultsTemplate = `${1 + (current - 1) * ItemsPerPage} - ${maxResults} of `;
 
     resultCountDiv.innerText = resultsTemplate;
 }
@@ -25,7 +30,7 @@ function updateCount(htmlItem) {
 const sortTables = (reach) => {
     var policyTable = new List('policy-docs-result-table', {
           valueNames: ['pub-name', 'organisation', 'authors', 'year'],
-          page: 25,
+          page: ItemsPerPage,
           innerWindow: 3,
           outerWindow: 3,
           pagination: true,
@@ -34,7 +39,7 @@ const sortTables = (reach) => {
 
     var citationTable = new List('citations-result-table', {
           valueNames: ['pub-name', 'organisation', 'authors', 'year'],
-          page: 25,
+          page: ItemsPerPage,
           innerWindow: 3,
           outerWindow: 3,
           pagination: true,

--- a/reach/web/src/js/sortTables.js
+++ b/reach/web/src/js/sortTables.js
@@ -1,0 +1,54 @@
+const List = require('list.js');
+
+function updateCount(htmlItem) {
+    let current = 1;
+    let trs = document.getElementsByTagName('tr');
+    let resultCountDiv = document.getElementById('result-count');
+    let maxEsResults = document.getElementById('max-results');
+    if (!maxEsResults) {
+    	return null;
+    } else {
+    	maxEsResults = parseInt(maxEsResults.innerText);
+    }
+
+
+    if (htmlItem && htmlItem.innerText) {
+        current = parseInt(htmlItem.innerText);
+    }
+
+    let maxResults = (maxEsResults < 25 || (25 + (current - 1) * 25) > maxEsResults)? maxEsResults : 25 + (current - 1) * 25;
+    let resultsTemplate = `${1 + (current - 1) * 25} - ${maxResults} of `;
+
+    resultCountDiv.innerText = resultsTemplate;
+}
+
+const sortTables = (reach) => {
+    var policyTable = new List('policy-docs-result-table', {
+          valueNames: ['pub-name', 'organisation', 'authors', 'year'],
+          page: 25,
+          innerWindow: 3,
+          outerWindow: 3,
+          pagination: true,
+    });
+
+
+    var citationTable = new List('citations-result-table', {
+          valueNames: ['pub-name', 'organisation', 'authors', 'year'],
+          page: 25,
+          innerWindow: 3,
+          outerWindow: 3,
+          pagination: true,
+    });
+
+    updateCount(false);
+
+    let pageLink = document.getElementsByClassName('pagination');
+    if (pageLink.length === 0) {
+    	return null;
+    }
+    pageLink[0].addEventListener('click', function(event) {
+        updateCount(event.target);
+    });
+};
+
+export default sortTables;

--- a/reach/web/templates/results/citations.html
+++ b/reach/web/templates/results/citations.html
@@ -3,7 +3,9 @@
 {% set status = es_status %}
 {% if es_response is mapping %}
     {% set status = status and (es_response.hits.total.value > 0) %}
-{% endif %}{% block header %}
+{% endif %}
+
+{% block header %}
 
 <header class="navbar">
   <section class="navbar-section">
@@ -77,71 +79,44 @@
             <div class="column col-6 hide-md"></div>
             {% endif %}
         </div>
+    </div>
     {% if status %}
-        <div class="container">
-            <div class="columns">
-                <div class="column col-6 col-md-12">
-                    {{ (page - 1) * size + 1 }} - {{ [(page - 1) * size + size, es_response.hits.total.value] | min }} of {{ es_response.hits.total.value }} results
-                </div>
-                <div class="column col-6 col-md-12">
-                    <div class="pagination-box float-right">
-
-                        <ul class="pagination">
-                            {% if page > 1 %}
-                                   <li class="page-item">
-                                    <a href="/search/citations?term={{ term }}&page={{ page - 1 }}">Prev</a>
-                                </li>
-                            {% else %}
-                                <li class="page-item disabled">
-                                    <a href="#" tabindex="-1">Prev</a>
-                                </li>
-                            {% endif %}
-                            {% for n_page in pages %}
-                                <li class="page-item {% if n_page == page %}active{% endif %}">
-                                    <a href="/search/citations?term={{ term }}&page={{ n_page }}">{{ n_page }}</a>
-                                </li>
-                            {% endfor %}
-                            {% if page < pages|length %}
-                                   <li class="page-item">
-                                    <a href="/search/citations?term={{ term }}&page={{ page + 1 }}">Next</a>
-                                </li>
-                            {% else %}
-                                <li class="page-item disabled">
-                                    <a href="#" tabindex="-1">Next</a>
-                                </li>
-                            {% endif %}
-                        </ul>
+        <div class="results">
+            <div class="container" id="citations-result-table">
+                <div class="columns">
+                    <div class="column col-6 col-md-12 text-left">
+                        <span  id="result-count">{#- Generated using JS #}</span>
+                        <span id="max-results">{{ es_response.hits.hits | length }}</span>
+                    </div>
+                    <div class="column col-6 col-md-12 text-right">
+                        {#- List.js will generate that for us #}
+                        <ul class="pagination"></ul>
                     </div>
                 </div>
-            </div>
-        </div>
-
-        <div class="results">
-            <div class="container">
                 <table class="table table-light table-hover">
                     <thead>
                         <tr>
-                            <th>Research Publication</th>
-                            <th>Journal</th>
-                            <th>Author(s)</th>
-                            <th>Year of publication</th>
-                            <th>Citations in Policy Docs</th>
+                            <th class="sort" data-sort="pub-name">Research Publication</th>
+                            <th class="sort" data-sort="journal">Journal</th>
+                            <th class="sort" data-sort="authors">Author(s)</th>
+                            <th class="sort" data-sort="year">Year of publication</th>
+                            <th class="sort" data-sort="citation-count">Citations in Policy Docs</th>
                         </tr>
                     </thead>
-                     <tbody>
+                     <tbody class="list">
                         {% for hit in es_response.hits.hits %}
                             <tr>
-                                <td>
+                                <td class="pub-name">
                                     {% if hit._source.doc.get('Matched title') %}
                                         {{ hit._source.doc.get('Matched title') | truncate(60) }}
                                     {% else %}
                                         No title
                                     {% endif %}
                                     </td>
-                                <td>{{ hit._source.doc.get('journal', 'No Journal') }}</td>
-                                <td>{{ hit._source.doc.get('authors', 'No Authors') }}</td>
-                                <td>{{ hit._source.doc.get('year', 'No Year') }}</td>
-                                <td>{{ hit._source.doc.get('citation_count', '-') }}</td>
+                                <td class="journal">{{ hit._source.doc.get('journal', 'No Journal') }}</td>
+                                <td class="authors">{{ hit._source.doc.get('authors', 'No Authors') }}</td>
+                                <td class="year">{{ hit._source.doc.get('year', 'No Year') }}</td>
+                                <td class="citation-count">{{ hit._source.doc.get('citation_count', '-') }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/reach/web/templates/results/policy-docs.html
+++ b/reach/web/templates/results/policy-docs.html
@@ -3,7 +3,9 @@
 {% set status = es_status %}
 {% if es_response is mapping %}
     {% set status = status and (es_response.hits.total.value > 0) %}
-{% endif %}{% block header %}
+{% endif %}
+
+{% block header %}
 
 <header class="navbar">
   <section class="navbar-section">
@@ -47,7 +49,7 @@
                 <p>Search by research publication title, journal, author or year of publication</p>
             </div>
             <div class="column col-6 col-md-12">
-                <form action="/search/citations">
+                <form action="/search/policy-docs">
                     <div class="input-group">
                       <input type="text" class="form-input input-xl" placeholder="Search" name="term" id="search-term" value="{{ term }}">
                       <button type="submit" class="btn btn-primary input-group-btn input-btn-xl">Browse policy documents <span class="icn icn-search"></span></button>
@@ -111,68 +113,41 @@
         {% endif %}
         </div>
     {% if status %}
-        <div class="container">
-            <div class="columns">
-                <div class="column col-6 col-md-12">
-                    {{ (page - 1) * size + 1 }} - {{ [(page - 1) * size + size, es_response.hits.total.value] | min }} of {{ es_response.hits.total.value }} results
-                </div>
-                <div class="column col-6 col-md-12">
-                    <div class="pagination-box float-right">
-
-                        <ul class="pagination">
-                            {% if page > 1 %}
-                                   <li class="page-item">
-                                    <a href="/search/policy-docs?term={{ term }}&page={{ page - 1 }}">Prev</a>
-                                </li>
-                            {% else %}
-                                <li class="page-item disabled">
-                                    <a href="#" tabindex="-1">Prev</a>
-                                </li>
-                            {% endif %}
-                            {% for n_page in pages %}
-                                <li class="page-item {% if n_page == page %}active{% endif %}">
-                                    <a href="/search/policy-docs?term={{ term }}&page={{ n_page }}">{{ n_page }}</a>
-                                </li>
-                            {% endfor %}
-                            {% if page < pages|length %}
-                                   <li class="page-item">
-                                    <a href="/search/policy-docs?term={{ term }}&page={{ page + 1 }}">Next</a>
-                                </li>
-                            {% else %}
-                                <li class="page-item disabled">
-                                    <a href="#" tabindex="-1">Next</a>
-                                </li>
-                            {% endif %}
-                        </ul>
+        <div class="results">
+            <div class="container" id="policy-docs-result-table">
+                <div class="columns">
+                    <div class="column col-6 col-md-12 text-left">
+                        <span  id="result-count">{#- Generated using JS #}</span>
+                        <span id="max-results">{{ es_response.hits.hits | length }}</span>
+                    </div>
+                    <div class="column col-6 col-md-12 text-right">
+                        {#- List.js will generate that for us #}
+                        <ul class="pagination"></ul>
                     </div>
                 </div>
-            </div>
-        </div>
 
-        <div class="results">
-            <div class="container">
                 <table class="table table-light table-hover">
                     <thead>
                         <tr>
-                            <th>Policy Document</th>
-                            <th>Organisation</th>
-                            <th>Author(s)</th>
-                            <th>Year of publication</th>
+                            <th class="sort" data-sort="pub-name">Policy Document</th>
+                            <th class="sort" data-sort="organisation">Organisation</th>
+                            <th class="sort" data-sort="authors">Author(s)</th>
+                            <th class="sort" data-sort="year">Year of publication</th>
                         </tr>
                     </thead>
-                     <tbody>
+                     <tbody class="list">
                         {% for hit in es_response.hits.hits %}
                             <tr>
-                                <td>
+                                <td class="pub-name">
                                     {% if hit._source.doc.text %}
                                         {{ hit._source.doc.text | truncate(60) }}
                                     {% else %}
                                         No title
                                     {% endif %}
                                     </td>
-                                <td>{{ hit._source.doc.organisation }}</td>
-                                <td>{{ hit._source.doc.authors }}</td>
-                                <td>{{ hit._source.doc.year }}</td>
+                                <td class="organisation">{{ hit._source.doc.organisation }}</td>
+                                <td class="authors">{{ hit._source.doc.get('authors', 'No authors') }}</td>
+                                <td class="year">{{ hit._source.doc.get('year', 'No year') }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
# Description

This PR adds sorting and pagination to the tables on Reach's web application.
 - Add List.js to the packages
 - Create some nice JS script to add sorting and pagination
 - Bit of rework on both result pages to allow pagination and sorting to happen

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?

`make docker-test`
local runs and tests
