### PR TITLE
airflow: Downgrading from 1.10.6 to 1.10.5 Fix #298

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Created by 'make update-requirements-txt'. DO NOT EDIT!
 alembic==1.1.0
 amqp==2.5.1
-apache-airflow[celery]==1.10.6
+apache-airflow[celery]==1.10.5
 apispec==2.0.2
 asn1crypto==0.24.0
 attrs==19.1.0


### PR DESCRIPTION
# Description

There's an issue with airflow 1.10.6 which has broken our pipeline, downgading
to 1.10.5 resovles the issue for now, will schedule testing the newer version
in the next sprint to see what needs to be changed in order to resolve the issue.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix #298 

# How Has This Been Tested?

- [x] make docker-test
- [x] Testing running some DAGs 

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
