### PR TITLE
Bugfix: query filter incorrect for elastic Fix #309

### DIFF
--- a/reach/elastic/common.py
+++ b/reach/elastic/common.py
@@ -117,7 +117,7 @@ def clear_index_by_org(es, org, index_name):
             body={
                 'query': {
                     'match': {
-                        'organisation': org,
+                        'doc.organisation': org,
                     }
                 }
             }


### PR DESCRIPTION
# Description

Fixes #309 

• Fixes an issue in elastic/common.clear_index_by_org where the key isn't correctly set resulting in duplicates in elastic on multiple subsequent runs of the DAG

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix 

# How Has This Been Tested?

`make docker-test`

Running the DAG task to ensure previous results are cleared from the index.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
