### PR TITLE
Bugfix: Downgrade airflow due to breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Created by 'make update-requirements-txt'. DO NOT EDIT!
 alembic==1.1.0
 amqp==2.5.1
-apache-airflow[celery]==1.10.5
+apache-airflow[celery]==1.10.4
 apispec==2.0.2
 asn1crypto==0.24.0
 attrs==19.1.0


### PR DESCRIPTION
# Description

Downgrading airflow back to 1.10.4 as 1.10.5 has a breaking change in how it sets up configuration

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix 

# How Has This Been Tested?

Untested

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
