### PR TITLE
Update fuzzy_match.py

### DIFF
--- a/reach/refparse/tests/test_fuzzy_match.py
+++ b/reach/refparse/tests/test_fuzzy_match.py
@@ -1,119 +1,98 @@
-import unittest
-
 import pandas as pd
+import pytest
 from pandas.util.testing import assert_frame_equal
-
-from reach.refparse.settings import settings
 from reach.refparse.utils import FuzzyMatcher
 
 
-class TestFuzzyMatcherInit(unittest.TestCase):
-    def test_empty_title(self):
-        real_publications = pd.DataFrame({
-            'title': []
-        })
-        threshold = 0.75
-        with self.assertRaises(ValueError):
-            FuzzyMatcher(real_publications, threshold)
+@pytest.fixture
+def fuzzy_matcher():
+    real_publications = [
+        {'title': 'Malaria', 'pmcid': 0},
+        {'title': 'Zika', 'pmcid': 1},
+    ]
+    fuzzy_matcher = FuzzyMatcher(real_publications, similarity_threshold=0.75)
 
-    def test_no_title(self):
-        real_publications = pd.DataFrame({})
-        threshold = 0.75
-        with self.assertRaises(KeyError):
-            FuzzyMatcher(real_publications, threshold)
+    return fuzzy_matcher
 
-    def test_no_string_titles(self):
-        real_publications = pd.DataFrame({
-            'title': [1,2]
-        })
-        threshold = 0.75
-        with self.assertRaises(AttributeError):
-            FuzzyMatcher(real_publications, threshold)
+def test_empty_list():
+    real_publications = []
+    with pytest.raises(ValueError):
+        FuzzyMatcher(real_publications, similarity_threshold=0.75)
 
-    def test_init_variables(self):
-        real_publications = pd.DataFrame({
-            'title': ['Malaria', 'Zika'],
-            'pmcid': [0, 1]
-        })
-        threshold = 0
-        fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
-        assert_frame_equal(
-            fuzzy_matcher.publications, real_publications
-        )
-        self.assertEqual(
-            fuzzy_matcher.similarity_threshold, threshold
-        )
-        self.assertTrue(
-            fuzzy_matcher.tfidf_matrix.size != 0
-        )
+def test_no_titles():
+    real_publications = [{}, {}, {}]
+    with pytest.raises(ValueError):
+        FuzzyMatcher(real_publications, similarity_threshold=0.75)
 
-    def test_init_variables_jsonl(self):
-        real_publications = pd.DataFrame(
-            {'title': 'Malaria', 'pmcid': 0},
-            {'title': 'Zika', 'pmcid': 1},
-        )
-        threshold = 0
-        fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
-        assert_frame_equal(
-            fuzzy_matcher.publications, real_publications
-        )
-        self.assertEqual(
-            fuzzy_matcher.similarity_threshold, threshold
-        )
-        self.assertTrue(
-            fuzzy_matcher.tfidf_matrix.size != 0
-        )
+def test_no_string_titles():
+    real_publications = [{'title':1}, {'title':2}]
+    with pytest.raises(AttributeError):
+        FuzzyMatcher(real_publications, similarity_threshold=0.75)
 
-class TestFuzzyMatch(unittest.TestCase):
-    def init_fuzzy_matcher(self):
-        real_publications = pd.DataFrame({
-            'title': ['Malaria', 'Zika'],
-            'uber_id': [1, 2]
-        })
-        threshold = settings.FUZZYMATCH_SIMILARITY_THRESHOLD
-        fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
+def test_init_variables():
+    real_publications = [
+        {'title': 'Malaria', 'pmcid': 0},
+        {'title': 'Zika', 'pmcid': 1},
+    ]
 
-        return fuzzy_matcher
+    threshold = 0.75
+    fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
+    assert isinstance(fuzzy_matcher.publications, dict)
+    assert isinstance(fuzzy_matcher.publications[0], dict)
+    assert fuzzy_matcher.publications[0] == real_publications[0]
+    assert fuzzy_matcher.similarity_threshold == threshold
+    assert fuzzy_matcher.tfidf_matrix.size != 0
 
-    def test_empty_reference(self):
-        fuzzy_matcher = self.init_fuzzy_matcher()
-        reference = {}
-        self.assertTrue(
-            fuzzy_matcher.match(reference) is None
-        )
 
-    def test_no_match(self):
-        fuzzy_matcher = self.init_fuzzy_matcher()
-        reference = {
-            'Document id': 1,
-            'Reference id': 1,
-            'Title': 'Ebola'
-        }
-        self.assertTrue(
-            fuzzy_matcher.match(reference) is None
-        )
 
-    def test_one_match(self):
-        fuzzy_matcher = self.init_fuzzy_matcher()
-        reference = {
-            'Document id': '10',
-            'Reference id': '11',
-            'Title': 'Malaria'
-        }
-        matched_publication = fuzzy_matcher.match(reference)
-        self.assertEqual(matched_publication['Document id'], '10')
+def test_empty_reference(fuzzy_matcher):
+    reference = {}
+    assert fuzzy_matcher.match(reference) is None
 
-    def test_close_match(self):
-        real_publications = pd.DataFrame({
-            'title': ['Malaria is caused by mosquitoes'],
-            'uber_id': [1]
-        })
-        threshold = settings.FUZZYMATCH_SIMILARITY_THRESHOLD
-        fuzzy_matcher = FuzzyMatcher(real_publications, threshold)
-        reference = {
-            'Document id':  '10',
-            'Reference id': '11',
-            'Title': 'Malaria'
-        }
-        matched_publication = fuzzy_matcher.match(reference)
-        self.assertEqual(matched_publication, None)
+def test_no_match(fuzzy_matcher):
+    reference = {
+        'Document id': 1,
+        'Reference id': 1,
+        'Title': 'Ebola'
+    }
+    assert fuzzy_matcher.match(reference) is None
+
+def test_one_match(fuzzy_matcher):
+    reference = {
+        'Document id': '10',
+        'Reference id': '11',
+        'Title': 'Malaria'
+    }
+    matched_publication = fuzzy_matcher.match(reference)
+    assert matched_publication['Document id'] == '10'
+
+def test_close_match():
+    real_publications = [
+        {'title': 'Malaria is caused by mosquitos', 'pmcid': 0},
+    ]
+    fuzzy_matcher = FuzzyMatcher(real_publications, similarity_threshold=0.75)
+
+    reference = {
+        'Document id':  '10',
+        'Reference id': '11',
+        'Title': 'Malaria',
+    }
+
+    matched_publication = fuzzy_matcher.match(reference)
+    assert matched_publication is None
+
+@pytest.mark.xfail(strict=True)
+def test_close_match_reverse(fuzzy_matcher):
+    """
+    This test is included to highlight somewhat unexpected behaviour, where
+    matches do not work in both directions. Compare to test above.
+    """
+
+    reference = {
+        'Document id':  '10',
+        'Reference id': '11',
+        'Title': 'Malaria is caused by mosquitos',
+    }
+
+    matched_publication = fuzzy_matcher.match(reference)
+    assert matched_publication is None

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -98,7 +98,6 @@ class FuzzyMatcher:
 
         retrieved_publications = [value for key, value in retrieved_publications.items()]
 
-
         retrieved_publications = sorted(retrieved_publications, key=lambda x: x['similarity'], reverse=True)
 
         return retrieved_publications
@@ -113,7 +112,7 @@ class FuzzyMatcher:
         if not reference:
             return None
 
-        if len(reference.get("Title")) < self.title_length_threshold:
+        if len(reference["Title"]) < self.title_length_threshold:
             return None
 
         retrieved_publications = self.search_publications(reference)
@@ -123,10 +122,10 @@ class FuzzyMatcher:
 
         if best_similarity > self.similarity_threshold:
             return {
-                "Document id": reference.get("Document id"),
-                "Reference id": reference.get("Reference id"),
-                "Extracted title": reference.get("Title"),
-                "Matched title": best_match.get("title"),
+                "Document id": reference["Document id"],
+                "Reference id": reference["Reference id"],
+                "Extracted title": reference["Title"],
+                "Matched title": best_match["title"],
                 "Matched publication id": best_match.get("uber_id"),
                 "Matched publication pmcid": best_match.get("pmcid"),
                 "Matched publication pmid": best_match.get("pmid"),

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -91,11 +91,19 @@ class FuzzyMatcher:
 
         if best_similarity > self.similarity_threshold:
             return {
-                "Document id": reference.get("Document id"),
-                "Reference id": reference.get("Reference id"),
+                "Document id": _str_or_null(reference.get("Document id")),
+                "Reference id": _str_or_null(reference.get("Reference id")),
                 "Extracted title": reference.get("Title"),
                 "Matched title": best_match.get("title"),
-                "Matched publication id": best_match.get("uber_id"),
+                "Matched publication id": _str_or_null(best_match.get("uber_id")),
+                "Matched publication pmcid": _str_or_null(best_match.get("pmcid")),
+                "Matched publication pmid": _str_or_null(best_match.get("pmid")),
+                "Matched publication doi": _str_or_null(best_match.get("doi")),
                 "Similarity": best_similarity,
                 "Match algorithm": "Fuzzy match",
             }
+
+def _str_or_null(docid):
+    if docid:
+        if isinstance(docid, float): docid = int(docid)
+    return str(docid)

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -118,7 +118,7 @@ class FuzzyMatcher:
         retrieved_publications = self.search_publications(reference)
 
         best_match = retrieved_publications[0]
-        best_similarity = best_match.get("similarity")
+        best_similarity = best_match["similarity"]
 
         if best_similarity > self.similarity_threshold:
             return {

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -1,15 +1,18 @@
-import numpy as np
 import logging
+
+import numpy as np
 
 import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
-
 logger = logging.getLogger(__name__)
 
+
 class FuzzyMatcher:
-    def __init__(self, publications, similarity_threshold=0.8, title_length_threshold=0):
+    def __init__(
+        self, publications, similarity_threshold=0.8, title_length_threshold=0
+    ):
         """
         Takes information about publications in the format:
 
@@ -75,7 +78,6 @@ class FuzzyMatcher:
             reference(dict): A structure reference in a dict, that minimally
                 contains the key: 'Title'.
         """
-
         if not reference:
             return None
 

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -122,20 +122,16 @@ class FuzzyMatcher:
         best_similarity = best_match.get("similarity")
 
         if best_similarity > self.similarity_threshold:
-             return {
-                "Document id": _str_or_null(reference.get("Document id")),
-                "Reference id": _str_or_null(reference.get("Reference id")),
+            return {
+                "Document id": reference.get("Document id"),
+                "Reference id": reference.get("Reference id"),
                 "Extracted title": reference.get("Title"),
                 "Matched title": best_match.get("title"),
-                "Matched publication id": _str_or_null(best_match.get("uber_id")),
-                "Matched publication pmcid": _str_or_null(best_match.get("pmcid")),
-                "Matched publication pmid": _str_or_null(best_match.get("pmid")),
-                "Matched publication doi": _str_or_null(best_match.get("doi")),
+                "Matched publication id": best_match.get("uber_id"),
+                "Matched publication pmcid": best_match.get("pmcid"),
+                "Matched publication pmid": best_match.get("pmid"),
+                "Matched publication doi": best_match.get("doi"),
                 "Similarity": best_similarity,
                 "Match algorithm": "Fuzzy match",
             }
 
-def _str_or_null(docid):
-    if docid :
-        if isinstance(docid, float) and docid: docid = int(docid)
-    return str(docid)

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -41,6 +41,9 @@ class FuzzyMatcher:
             title_length_threhold(float): Minimum allowed length of title.
                 Less than this threshold will return no results.
         """
+        # Filter out any publications that don't have titles
+
+        publications = [pub for pub in publications if pub.get("title")]
         self.publications = pd.DataFrame(publications)
         self.vectorizer = TfidfVectorizer(lowercase=True, ngram_range=(1, 1))
         self.tfidf_matrix = self.vectorizer.fit_transform(self.publications.get("title"))

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -43,9 +43,7 @@ class FuzzyMatcher:
         """
         self.publications = pd.DataFrame(publications)
         self.vectorizer = TfidfVectorizer(lowercase=True, ngram_range=(1, 1))
-        self.tfidf_matrix = self.vectorizer.fit_transform(
-            self.publications['title']
-        )
+        self.tfidf_matrix = self.vectorizer.fit_transform(self.publications.get("title"))
         self.similarity_threshold = similarity_threshold
         self.title_length_threshold = title_length_threshold
 
@@ -57,15 +55,14 @@ class FuzzyMatcher:
             nb_results(int): Number of results to return. This will be the top
                 n results, ordered by similarity score.
         """
-        title_vector = self.vectorizer.transform(
-            [reference['Title']]
-        )[0]
-        title_similarities = cosine_similarity(
-            title_vector, self.tfidf_matrix
-        )[0]
+        title_vector = self.vectorizer.transform([reference.get("Title")])[0]
+        title_similarities = cosine_similarity(title_vector, self.tfidf_matrix)[0]
         retrieved_publications = self.publications.copy()
-        retrieved_publications['similarity'] = title_similarities
-        retrieved_publications.sort_values(by='similarity', ascending=False, inplace=True)
+        retrieved_publications["similarity"] = title_similarities
+        retrieved_publications.sort_values(
+            by="similarity", ascending=False, inplace=True
+        )
+
         return retrieved_publications[:nb_results]
 
     def match(self, reference):
@@ -78,18 +75,22 @@ class FuzzyMatcher:
 
         if not reference:
             return None
-        if len(reference['Title']) < self.title_length_threshold:
+
+        if len(reference.get("Title")) < self.title_length_threshold:
             return None
 
         retrieved_publications = self.search_publications(reference)
 
         best_match = retrieved_publications.iloc[0]
-        best_similarity = best_match['similarity']
+        best_similarity = best_match.get("similarity")
+
         if best_similarity > self.similarity_threshold:
             return {
-                'Matched title': best_match['title'],
-                'Matched publication id': best_match['uber_id'],
-                'Similarity': best_similarity,
-                'Match algorithm': 'Fuzzy match'
+                "Document id": reference.get("Document id"),
+                "Reference id": reference.get("Reference id"),
+                "Extracted title": reference.get("Title"),
+                "Matched title": best_match.get("title"),
+                "Matched publication id": best_match.get("uber_id"),
+                "Similarity": best_similarity,
+                "Match algorithm": "Fuzzy match",
             }
-

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -36,8 +36,8 @@ class FuzzyMatcher:
         ```
 
         Args:
-            publications(list): List of dicst containing publication info as
-                above.
+            publications(list): List of dicts containing publication info as
+                above, or a pandas.DataFrame.
             similarity_threshold(float): Minimum allowable similarity
                 threshold. If not results are found to have a similarity
                 higher than this, then nothing is returned.
@@ -46,10 +46,9 @@ class FuzzyMatcher:
         """
         # Filter out any publications that don't have titles
 
-        publications = [pub for pub in publications if pub.get("title")]
         self.publications = pd.DataFrame(publications)
         self.vectorizer = TfidfVectorizer(lowercase=True, ngram_range=(1, 1))
-        self.tfidf_matrix = self.vectorizer.fit_transform(self.publications.get("title"))
+        self.tfidf_matrix = self.vectorizer.fit_transform(self.publications["title"])
         self.similarity_threshold = similarity_threshold
         self.title_length_threshold = title_length_threshold
 

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -10,7 +10,18 @@ from sklearn.metrics.pairwise import cosine_similarity
 logger = logging.getLogger(__name__)
 
 class FuzzyMatcher:
-    def __init__(self, publications, similarity_threshold, title_length_threshold=0):
+    def __init__(self, publications, similarity_threshold=0.8, title_length_threshold=0):
+        """
+        Args:
+            publications(list): A list of dicts containing reference information
+                from a canonical list of publications, which minially contain
+                the key 'title'.
+            similarity_threshold(float): Minimum allowable similarity
+                threshold. If not results are found to have a similarity
+                higher than this, then nothing is returned.
+            title_length_threhold(float): Minimum allowed length of title.
+                Less than this threshold will return no results.
+        """
         self.publications = pd.DataFrame(publications)
         self.vectorizer = TfidfVectorizer(lowercase=True, ngram_range=(1, 1))
         self.tfidf_matrix = self.vectorizer.fit_transform(
@@ -20,6 +31,13 @@ class FuzzyMatcher:
         self.title_length_threshold = title_length_threshold
 
     def search_publications(self, reference, nb_results=10):
+        """
+        Args:
+            reference(dict): A structure reference in a dict, that minimally
+                contain the key: 'title'.
+            nb_results(int): Number of results to return. This will be the top
+                n results, ordered by similarity score.
+        """
         title_vector = self.vectorizer.transform(
             [reference['Title']]
         )[0]
@@ -32,10 +50,16 @@ class FuzzyMatcher:
         return retrieved_publications[:nb_results]
 
     def match(self, reference):
+        """
+        Args:
+            reference(dict): A structure reference in a dict, that minimally
+                contain the key: 'Title'.
+        """
+
         if not reference:
-            return
+            return None
         if len(reference['Title']) < self.title_length_threshold:
-            return
+            return None
 
         retrieved_publications = self.search_publications(reference)
 
@@ -43,11 +67,9 @@ class FuzzyMatcher:
         best_similarity = best_match['similarity']
         if best_similarity > self.similarity_threshold:
             return {
-                'Document id': reference['Document id'],
-                'Reference id': reference['Reference id'],
-                'Extracted title': reference['Title'],
                 'Matched title': best_match['title'],
                 'Matched publication id': best_match['uber_id'],
                 'Similarity': best_similarity,
                 'Match algorithm': 'Fuzzy match'
             }
+

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -11,10 +11,30 @@ logger = logging.getLogger(__name__)
 class FuzzyMatcher:
     def __init__(self, publications, similarity_threshold=0.8, title_length_threshold=0):
         """
+        Takes information about publications in the format:
+
+        ```
+
+        [
+            {
+            "pmid": 18568110,
+            "pmcid": "PMC2424117",
+            "title": "Fluvoxamine in the treatment of anxiety disorders.",
+            "authors": [{"LastName": "Irons", "Initials": "J"}],
+            "journalTitle": "Neuropsychiatric disease and treatment",
+            "issue": "4",
+            "journalVolume": "1",
+            "pubYear": 2005,
+            "journalISSN": "1176-6328",
+            "pubType": "\"Journal Article\""
+            },
+            ...
+        ]
+        ```
+
         Args:
-            publications(list): A list of dicts containing reference information
-                from a canonical list of publications, which minially contain
-                the key 'title'.
+            publications(list): List of dicst containing publication info as
+                above.
             similarity_threshold(float): Minimum allowable similarity
                 threshold. If not results are found to have a similarity
                 higher than this, then nothing is returned.
@@ -33,7 +53,7 @@ class FuzzyMatcher:
         """
         Args:
             reference(dict): A structure reference in a dict, that minimally
-                contain the key: 'title'.
+                contains the key: 'Title'.
             nb_results(int): Number of results to return. This will be the top
                 n results, ordered by similarity score.
         """
@@ -49,10 +69,11 @@ class FuzzyMatcher:
         return retrieved_publications[:nb_results]
 
     def match(self, reference):
+
         """
         Args:
             reference(dict): A structure reference in a dict, that minimally
-                contain the key: 'Title'.
+                contains the key: 'Title'.
         """
 
         if not reference:

--- a/reach/refparse/utils/fuzzy_match.py
+++ b/reach/refparse/utils/fuzzy_match.py
@@ -2,7 +2,6 @@ import numpy as np
 import logging
 
 import pandas as pd
-from reach.refparse.settings import settings
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 


### PR DESCRIPTION
# Description

Updates the `FuzzyMatch` class by removing the reliance on pandas, instead using a indices and lists of dicts. This approach cuts the time taken to match 620 references against a list of 5 million publication from a ~10-15s search time to ~3-5s search time, reducing time taken from over two hours to just under one.

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature (refactor)
- [x] :memo: Documentation update

# How Has This Been Tested?

`make # docker tests`

Also, manually labelled titles extracted from the validation for the 2019.10.8 model were matched against the 5 million publications.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes