### PR TITLE
Fix grab section duplications

### DIFF
--- a/reach/airflow/dags/policy.py
+++ b/reach/airflow/dags/policy.py
@@ -250,7 +250,10 @@ def create_dag_fuzzy_match(dag_id, default_args, spider_years,
     esIndexPublications = es_index_publications(dag, item_limits)
     for organisation in ORGANISATIONS:
         create_org_pipeline_fuzzy_match(
-            dag, organisation, item_limits, spider_years,
+            dag,
+            organisation,
+            item_limits,
+            spider_years,
             esIndexPublications)
     return dag
 

--- a/reach/airflow/tasks/fuzzy_match_refs.py
+++ b/reach/airflow/tasks/fuzzy_match_refs.py
@@ -213,3 +213,8 @@ class FuzzyMatchRefsOperator(BaseOperator):
                 count, match_count
             )
 
+            logger.info(
+                    'FuzzyMatchRefsOperator: Matches saved to %s',
+                    s3.get_key(self.dst_s3_key)
+                )
+

--- a/reach/airflow/tasks/policy_name_normalizer.py
+++ b/reach/airflow/tasks/policy_name_normalizer.py
@@ -120,7 +120,6 @@ class PolicyNameNormalizerOperator(BaseOperator):
                         'created': pdf_meta.get("created", None),
                         'types': source_meta.get("types", None)
                     }))
-
         # Write the results to S3
         with tempfile.NamedTemporaryFile(mode='wb') as output_raw_f:
             with gzip.GzipFile(mode='wb', fileobj=output_raw_f) as output_f:
@@ -135,7 +134,7 @@ class PolicyNameNormalizerOperator(BaseOperator):
                 replace=True
             )
             logger.info(
-                'PolicyNameNormalizerOperator: Done normalizing poicy names'
+                'PolicyNameNormalizerOperator: Done normalizing policy names'
             )
 
 

--- a/reach/pdf_parser/pdf_parse.py
+++ b/reach/pdf_parser/pdf_parse.py
@@ -183,6 +183,11 @@ def grab_section(pdf_file, keyword):
     elements = _find_elements(pdf_file, keyword)
     for start_title, end_title in elements:
         text = ''
+        # If there is no end to this section, then get text from
+        # the start of this section until the end of the entire document.
+        # For sections where start page = end page, need
+        # to add 1 to the end page number otherwise no text will be
+        # appended in the for loop (list(range(x,x)) = [])
         if not end_title:
             end_page = len(pdf_file.pages)
         elif (start_title.page_number != end_title.page_number):

--- a/reach/pdf_parser/pdf_parse.py
+++ b/reach/pdf_parser/pdf_parse.py
@@ -178,22 +178,24 @@ def grab_section(pdf_file, keyword):
     """Given a pdf parsed file object (PdfFile) and a keyword corresponding to
     a title, returns the matching section of the pdf text.
     """
+
     result = ''
-    text = ''
     elements = _find_elements(pdf_file, keyword)
     for start_title, end_title in elements:
+        text = ''
         if not end_title:
             end_page = len(pdf_file.pages)
+        elif (start_title.page_number != end_title.page_number):
+            end_page = end_title.page_number
         else:
             end_page = end_title.page_number + 1
         for page_number in range(start_title.page_number, end_page):
             if pdf_file.get_page(page_number).get_page_text(True):
                 text += pdf_file.get_page(page_number).get_page_text()
-        if end_title and (start_title.page_number != end_title.page_number):
+        if end_title:
             result += text[
-                text.find(start_title.text):text.find(end_title.text)
-            ]
+                    text.find(start_title.text):text.find(end_title.text)
+                ]
         else:
             result += text[text.find(start_title.text):]
-        text = ''
     return result

--- a/reach/pdf_parser/tools/extraction.py
+++ b/reach/pdf_parser/tools/extraction.py
@@ -56,6 +56,8 @@ def _find_elements(pdf_file, keyword):
 
     # Get all the line of found title font size
     titles_section = pdf_file.get_lines_by_font_size(titles_font_size)
+    # Sometimes titles text can be whitespaces but happen to be in the titles_font_size, remove these
+    titles_section = [t for t in titles_section if t.text.strip() != ""]
     start_title = None
     for line in titles_section:
         if start_title:


### PR DESCRIPTION
# Description
Fix #183 
We find repeated chunks of text when getting the sections, despite the repeated text not being in the full text scrape.
This bug was in the grab sections code.
e.g.
Before the references section grabbed from [this document](https://www.nice.org.uk/guidance/ph31/resources/unintentional-injuries-on-the-road-interventions-for-under-15s-pdf-1996292434885) was repeating the 1st page of references:
```
"References\nReferences\nAudit Commission and Healthcare Commission (2007) Better safe than sorry: preventing\nunintentional injury to children. London: Audit Commission\nDavis R, Pless B (2001) BMJ bans 'accident'. BMJ 322: 1320–1\nDepartment for Transport (2007) Child road safety strategy 2007. London: Department for\nTransport.\nDepartment for Transport (2008) Road casualties Great Britain: 2007 annual report. London: The\nStationery Office\nDepartment for Transport (2010a) Road casualties Great Britain: 2009 annual report. London: The\nStationery Office\nDepartment for Transport (2010b) Child casualties in reported road accidents Great Britain: 2008\nRoad Accident Statistics Factsheet No. 5. London: Department for Transport\nDepartment of the Environment, Transport and the Regions (2001) Road accident involvement of\nchildren from ethnic minorities: a literature review. London: Department of Environment,\nTransport and the Regions\nEdwards P, Roberts I, Green J, et al. (2006) Deaths from injury in children and employment status in\nfamily: analysis of trends in class specific death rates. British Medical Journal 333: 119–21\nGreyling T, Hallam K, Daniel G, et al. (2002) Streets ahead: safe and liveable streets for children.\nLondon: Institute for Public Policy Research\nOffice for National Statistics (2009) Mortality statistics: deaths registered in 2008. London: Office\nfor National Statistics\nPlay England (2007) Playday 2007 – Our streets too! London: Play England\nRacioppi F, Ericsson L, Tingvall C et al. (2004) Preventing road traffic injury: a public health\nperspective for Europe. Copenhagen: World Health Organization\nUnintentional injuries on the road: interventions for under 15s (PH31)\n© NICE 2019. All rights reserved. Subject to Notice of rights (https://www.nice.org.uk/terms-and-\nconditions#notice-of-rights).\nPage 23 of\n48\n
References\nReferences\nAudit Commission and Healthcare Commission (2007) Better safe than sorry: preventing\nunintentional injury to children. London: Audit Commission\nDavis R, Pless B (2001) BMJ bans 'accident'. BMJ 322: 1320–1\nDepartment for Transport (2007) Child road safety strategy 2007. London: Department for\nTransport.\nDepartment for Transport (2008) Road casualties Great Britain: 2007 annual report. London: The\nStationery Office\nDepartment for Transport (2010a) Road casualties Great Britain: 2009 annual report. London: The\nStationery Office\nDepartment for Transport (2010b) Child casualties in reported road accidents Great Britain: 2008\nRoad Accident Statistics Factsheet No. 5. London: Department for Transport\nDepartment of the Environment, Transport and the Regions (2001) Road accident involvement of\nchildren from ethnic minorities: a literature review. London: Department of Environment,\nTransport and the Regions\nEdwards P, Roberts I, Green J, et al. (2006) Deaths from injury in children and employment status in\nfamily: analysis of trends in class specific death rates. British Medical Journal 333: 119–21\nGreyling T, Hallam K, Daniel G, et al. (2002) Streets ahead: safe and liveable streets for children.\nLondon: Institute for Public Policy Research\nOffice for National Statistics (2009) Mortality statistics: deaths registered in 2008. London: Office\nfor National Statistics\nPlay England (2007) Playday 2007 – Our streets too! London: Play England\nRacioppi F, Ericsson L, Tingvall C et al. (2004) Preventing road traffic injury: a public health\nperspective for Europe. Copenhagen: World Health Organization\nUnintentional injuries on the road: interventions for under 15s (PH31)\n© NICE 2019. All rights reserved. Subject to Notice of rights (https://www.nice.org.uk/terms-and-\nconditions#notice-of-rights).\nPage 23 of\n48\n
Sonkin B, Edwards P, Roberts I et al. (2006) Walking, cycling and transport safety: an analysis of\nchild road deaths. Journal of the Royal Society of Medicine 99: 402–5\nTowner E, Dowswell T, Errington G et al. (2005) Injuries in children aged 0–14 years and\ninequalities. London: Health Development Agency\nWorld Health Organization (2004) World report on road traffic injury prevention. Geneva: World\nHealth Organization\nUnintentional injuries on the road: interventions for under 15s (PH31)\n© NICE 2019. All rights reserved. Subject to Notice of rights (https://www.nice.org.uk/terms-and-\nconditions#notice-of-rights).\nPage 24 of\n48\n"
```
now it is correctly:
```
"References\nReferences\nAudit Commission and Healthcare Commission (2007) Better safe than sorry: preventing\nunintentional injury to children. London: Audit Commission\nDavis R, Pless B (2001) BMJ bans 'accident'. BMJ 322: 1320–1\nDepartment for Transport (2007) Child road safety strategy 2007. London: Department for\nTransport.\nDepartment for Transport (2008) Road casualties Great Britain: 2007 annual report. London: The\nStationery Office\nDepartment for Transport (2010a) Road casualties Great Britain: 2009 annual report. London: The\nStationery Office\nDepartment for Transport (2010b) Child casualties in reported road accidents Great Britain: 2008\nRoad Accident Statistics Factsheet No. 5. London: Department for Transport\nDepartment of the Environment, Transport and the Regions (2001) Road accident involvement of\nchildren from ethnic minorities: a literature review. London: Department of Environment,\nTransport and the Regions\nEdwards P, Roberts I, Green J, et al. (2006) Deaths from injury in children and employment status in\nfamily: analysis of trends in class specific death rates. British Medical Journal 333: 119–21\nGreyling T, Hallam K, Daniel G, et al. (2002) Streets ahead: safe and liveable streets for children.\nLondon: Institute for Public Policy Research\nOffice for National Statistics (2009) Mortality statistics: deaths registered in 2008. London: Office\nfor National Statistics\nPlay England (2007) Playday 2007 – Our streets too! London: Play England\nRacioppi F, Ericsson L, Tingvall C et al. (2004) Preventing road traffic injury: a public health\nperspective for Europe. Copenhagen: World Health Organization\nUnintentional injuries on the road: interventions for under 15s (PH31)\n© NICE 2019. All rights reserved. Subject to Notice of rights (https://www.nice.org.uk/terms-and-\nconditions#notice-of-rights).\nPage 23 of\n48\n
Sonkin B, Edwards P, Roberts I et al. (2006) Walking, cycling and transport safety: an analysis of\nchild road deaths. Journal of the Royal Society of Medicine 99: 402–5\nTowner E, Dowswell T, Errington G et al. (2005) Injuries in children aged 0–14 years and\ninequalities. London: Health Development Agency\nWorld Health Organization (2004) World report on road traffic injury prevention. Geneva: World\nHealth Organization\nUnintentional injuries on the road: interventions for under 15s (PH31)\n© NICE 2019. All rights reserved. Subject to Notice of rights (https://www.nice.org.uk/terms-and-\nconditions#notice-of-rights).\nPage 24 of\n48"
```
I've run the test dag for NICE and found fewer repeats in the fuzzy match results. There should still be a few repeats since it is possible for a policy document to have multiple of the same citation in (e.g. if there were multiple references sections).

Just to highlight that if you are wondering why the numbers of references found is now a lot lower, then this could be it.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [ ] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?
There is one test that fails - test_fuzzy_match/test_close_match_reverse
I'm actually confused about this test, and expect that it was broken before this PR. It is labelled with `@pytest.mark.xfail(strict=True)`. I think @ivyleavedtoadflax should be able to shed some light on this?

Otherwise
```
>>> make docker-test
74 passed, 1 xfailed, 4 warnings in 2.96s
>>> make test
72 passed, 2 skipped, 1 xfailed, 5 warnings in 2.11s
```

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
