### PR TITLE
Fix Unicef title crawling

### DIFF
--- a/reach/scraper/wsf_scraping/spiders/unicef_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/unicef_spider.py
@@ -52,7 +52,7 @@ class UnicefSpider(BaseSpider):
         @returns items 0 0
         """
 
-        title = response.css('.entry-heading h1::text').extract_first()
+        title = response.css('h1::text').extract_first()
         hrefs = response.css('a::attr("href")').extract()
         ls = list(filter(lambda x: self._is_valid_pdf_url(x), hrefs))
 


### PR DESCRIPTION
# Description

We are currently scraping titles from Unicef (e.g. https://data.unicef.org/resources/child-protection-resource-pack/) using a css selector for a class that doesn't exist, which caused the scraped titles to be null. The proposed changes fixes this behaviour. 

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

`make test` and `make docker-test`. 

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] existing unit tests pass locally with my changes

All tests pass, except for fuzzy match test that `xfails`:

```

collected 75 items                                                                                                                                                                                         

reach/pdf_parser/tests/test_db_tools.py ..
reach/pdf_parser/tests/test_pdf_objects.py ..........ss.
reach/pdf_parser/tests/test_pdf_parser_tools.py ....
reach/refparse/tests/test_exact_match.py ........
reach/refparse/tests/test_fuzzy_match.py ........x
reach/refparse/tests/test_parse.py ...............
reach/refparse/tests/test_split.py ....
reach/scraper/tests/test_gov_spider.py ...
reach/scraper/tests/test_msf_spider.py ..
reach/scraper/tests/test_nice_spider.py ....
reach/scraper/tests/test_parliament_spider.py ...
reach/scraper/tests/test_scraper_spiders.py .
reach/scraper/tests/test_unicef_spider.py ...
reach/scraper/tests/test_who_spider.py ...
reach/web/tests/test_template.py .

=========================================================================== 72 passed, 2 skipped, 1 xfailed, 5 warnings in 3.76s ===========================================================================

```

