### PR TITLE
Group policy documents by research paper in Reach web app

### DIFF
--- a/reach/airflow/tasks/fuzzy_match_refs.py
+++ b/reach/airflow/tasks/fuzzy_match_refs.py
@@ -101,7 +101,6 @@ class ElasticsearchFuzzyMatcher:
                 'reference_id': reference.get('Reference id', None),
                 'extracted_title': reference.get('Title', None),
                 'similarity': best_score,
-                'organisation': self.organisation,
 
                 # Matched reference information
                 'match_title': matched_reference.get('doc', {}).get('title', 'Unknown'),
@@ -123,6 +122,7 @@ class ElasticsearchFuzzyMatcher:
                     'source_page': ref_metadata.get('source_page', None),
                     'source_page_title': ref_metadata.get('source_page_title', None),
                     'pdf_creator': ref_metadata.get('creator', None),
+                    'organisation': self.organisation,
                 }]
             }
 

--- a/reach/airflow/tasks/fuzzy_match_refs.py
+++ b/reach/airflow/tasks/fuzzy_match_refs.py
@@ -193,13 +193,13 @@ class FuzzyMatchRefsOperator(BaseOperator):
                 structured_reference
             )
             if fuzzy_matched_reference:
-                title = fuzzy_matched_reference['match_title']
-                if title in references.keys():
-                    references[title]['policies'].append(
+                ref_id = fuzzy_matched_reference['reference_id']
+                if ref_id in references.keys():
+                    references[ref_id]['policies'].append(
                         fuzzy_matched_reference['policies'][0]
                     )
                 else:
-                    references[title] = fuzzy_matched_reference
+                    references[ref_id] = fuzzy_matched_reference
 
                 match_count += 1
                 if match_count % 100 == 0:

--- a/reach/elastic/common.py
+++ b/reach/elastic/common.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
 from urllib.parse import urlparse
+import json
 import gzip
 import logging
 import tempfile

--- a/reach/elastic/fuzzy_matched_citations.py
+++ b/reach/elastic/fuzzy_matched_citations.py
@@ -33,11 +33,22 @@ def clean_es(es, es_index, org):
     current_mapping = common.check_mapping(es, es_index)
     if current_mapping:
         org_mapping = current_mapping[es_index][
-            'mappings']['properties']['doc']['properties']['organisation']
+            'mappings']['properties']['doc']['properties'][
+            'policies']['properties']['organisation']
 
         if org_mapping.get('type') == 'keyword':
             logging.info('current mapping is set - cleaning index for ' + org)
-            common.clear_index_by_org(es, org, es_index)
+            common.clear_index_by_query(
+                es,
+                query={
+                    'query': {
+                        'match': {
+                            'doc.policies.organisation': org,
+                        }
+                    }
+                },
+                index_name=es_index,
+            )
             return
 
     mapping_body = {
@@ -47,11 +58,11 @@ def clean_es(es, es_index, org):
                     "type": "text",
                     "fields": {"keyword": {"type": "keyword"}}
                 },
-                "doc.policy_title": {
+                "doc.policies.title": {
                     "type": "text",
                     "fields": {"keyword": {"type": "keyword"}}
                 },
-                "doc.organisation": {"type": "keyword"},
+                "doc.policies.organisation": {"type": "keyword"},
                 "doc.match_source": {"type": "keyword"},
                 "doc.match_publication": {"type": "keyword"},
                 "doc.match_authors": {

--- a/reach/web/src/css/icons.css
+++ b/reach/web/src/css/icons.css
@@ -11,3 +11,17 @@
 	margin-bottom: -4px;
 	content: url(../images/Icon_Download_16px.svg);
 }
+
+.icn.icn-research-paper::before {
+	color: black;
+	fill: black;
+	margin-bottom: -4px;
+	content: url(../images/Icon_Research_24px.svg);
+}
+
+.icn.icn-sort::before {
+	color: black;
+	fill: black;
+	margin-bottom: -4px;
+	content: url(../images/Icon_Sort-by_16px.svg);
+}

--- a/reach/web/src/css/results.css
+++ b/reach/web/src/css/results.css
@@ -10,6 +10,10 @@
 		border-top: 1px solid $greyLight;
 		border-bottom: 1px solid $greyLight;
 	}
+
+	.authors-cell {
+		width: 20%;
+	}
 }
 .pagination .page-item#active-page {
 	background-color: $cyanPrimary;
@@ -55,11 +59,11 @@ th {
   letter-spacing: 0.5px;
   color: $greyLink;
 }
-
+/*
 .sort::after {
 	content: url(../images/Icon_Sort-by_16px.svg);
 	margin-left: 10px;
-}
+}*/
 
 .accordion-arrow {
 	color: $cyanPrimary;

--- a/reach/web/src/css/results.css
+++ b/reach/web/src/css/results.css
@@ -56,12 +56,22 @@ th {
   color: $greyLink;
 }
 
-#citations-result-table th:first-child::before {
-	content: url(../images/Icon_Research_24px.svg);
-	margin-right: 10px;
-}
-
-th::after {
+.sort::after {
 	content: url(../images/Icon_Sort-by_16px.svg);
 	margin-left: 10px;
+}
+
+.accordion-arrow {
+	color: $cyanPrimary;
+	font-weight: bold;
+	width: 3.4375rem;
+	text-align: center;
+	font-size:
+}
+.accordion-subtable {
+	width: 100%;
+}
+.accordion-subtable-container {
+	width: 100%;
+	padding-left: 3.4375rem;
 }

--- a/reach/web/src/css/results.css
+++ b/reach/web/src/css/results.css
@@ -66,12 +66,30 @@ th {
 	font-weight: bold;
 	width: 3.4375rem;
 	text-align: center;
-	font-size:
 }
+
+.active-row td {
+	background-color: $backgroundTint2;
+}
+
 .accordion-subtable {
-	width: 100%;
+	tr td {
+		border: none;
+		background-color: $backgroundTint1;
+	}
+
+	tr th{
+		border: none;
+		background-color: $backgroundTint1;
+	}
 }
-.accordion-subtable-container {
-	width: 100%;
+
+.table tr .accordion-subtable-container {
+	background-color: $backgroundTint1;
+	padding: 0;
 	padding-left: 3.4375rem;
+}
+
+#citations-results-tbody .hidden {
+	display: none;
 }

--- a/reach/web/src/css/results.css
+++ b/reach/web/src/css/results.css
@@ -59,11 +59,6 @@ th {
   letter-spacing: 0.5px;
   color: $greyLink;
 }
-/*
-.sort::after {
-	content: url(../images/Icon_Sort-by_16px.svg);
-	margin-left: 10px;
-}*/
 
 .accordion-arrow {
 	color: $cyanPrimary;

--- a/reach/web/src/css/style.css
+++ b/reach/web/src/css/style.css
@@ -264,4 +264,82 @@ a, a:visited {
 .form-input:focus {
   border-color: #767676;
   box-shadow: none;
+
+/* Override Spectre default */
+.breadcrumb .breadcrumb-item:not(:last-child) a {
+    color: $cyanPrimary;
+}
+
+.table.table-hover tbody tr:hover {
+  background: $backgroundTint1;
+}
+
+.breadcrumb .breadcrumb-item:not(:first-child)::before {
+  color: $greyDark;
+  content: ">";
+  padding-right: .4rem;
+}
+
+.breadcrumb .breadcrumb-item {
+  color: $greyDark;
+}
+
+#breadcrumbs {
+  background: white;
+  border-bottom: 1px solid $greyLight;
+}
+
+
+@media screen and (min-width: 1280px) {
+   #breadcrumbs {
+     padding: 0 $guidePadding;
+   }
+}
+
+@media screen and (max-width: 1280px) {
+   #breadcrumbs {
+     padding: 0 1.375rem;
+   }
+}
+
+/* Help tooltip */
+.help {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
+  border-radius: 50%;
+  line-height: 22px;
+  text-align: center;
+  background-color: $cyanPrimary;
+  margin-top: 2.7ex;
+}
+
+section#hero a.btn-primary:hover,
+section#hero .btn.help:hover {
+  border: 1px solid white;
+}
+
+.hero-button {
+    height: 3.5rem;
+    line-height: 3.5rem;
+    font-size: $baseFontSize;
+    padding: 0 $smallPadding;
+}
+.popover-container {
+  display: block;
+  opacity: 1;
+  transform: translate(-50%, -100%) scale(1);
+}
+
+.popover-container svg.arrow {
+  margin: -1em auto 0 auto;
+  width: 2em;
+  height: 1em;
+}
+
+.popover-container .card {
+  color: $greyDark;
 }

--- a/reach/web/src/js/citationsTable.js
+++ b/reach/web/src/js/citationsTable.js
@@ -3,8 +3,8 @@ import {getCurrentState, getPagination, getCounter, getData} from './resultsComm
 const size = 25;
 const searchFields = [
     'match_title',
-    'policy_title',
-    'organisation',
+    'policies.title',
+    'policies.organisation',
     'match_source',
     'match_publication',
     'match_authors'
@@ -32,13 +32,13 @@ function getCitationsTableContent(data) {
                             <th>Year of Publicaction</th>
                         </tr>
         `;
-        item._source.doc.policies.forEach((item) => {
+        for (let policy of item._source.doc.policies) {
             rows += `<tr>`;
-            rows += `<td><a href="${item.source_url}">${item.title}</a></td>`;
-            rows += `<td>${item.organisation}</td>`;
-            rows += `<td>${item.authors}</td>`;
-            rows += `<td>${item.year}</td>`;
-        });
+            rows += `<td><a href="${policy.source_url}">${policy.title}</a></td>`;
+            rows += `<td>${policy.organisation}</td>`;
+            rows += `<td>${policy.authors}</td>`;
+            rows += `<td>${item._source.doc.match_pub_year}</td>`;
+        }
         rows += `</table></td>`
         rows += `</tr>`;
     });

--- a/reach/web/src/js/citationsTable.js
+++ b/reach/web/src/js/citationsTable.js
@@ -17,7 +17,7 @@ function getCitationsTableContent(data) {
         rows += `<td class="accordion-arrow"><i class="icon icon-arrow-down mr-1"></i></td>`
         rows += `<td>${item._source.doc.match_title}</td>`;
         rows += `<td>${item._source.doc.match_publication}</td>`;
-        rows += `<td>${item._source.doc.match_authors}</td>`;
+        rows += `<td class="authors-cell">${item._source.doc.match_authors}</td>`;
         rows += `<td>${item._source.doc.match_pub_year}</td>`;
         rows += `<td>${item._source.doc.policies.length}</td>`;
         rows += `</tr>`;
@@ -34,7 +34,7 @@ function getCitationsTableContent(data) {
         `;
         item._source.doc.policies.forEach((item) => {
             rows += `<tr>`;
-            rows += `<td>${item.title}</td>`;
+            rows += `<td><a href="${item.source_url}">${item.title}</a></td>`;
             rows += `<td>${item.organisation}</td>`;
             rows += `<td>${item.authors}</td>`;
             rows += `<td>${item.year}</td>`;

--- a/reach/web/src/js/citationsTable.js
+++ b/reach/web/src/js/citationsTable.js
@@ -13,16 +13,35 @@ const searchFields = [
 function getCitationsTableContent(data) {
     let rows = ``;
     data.hits.hits.forEach((item) => {
-        rows += `<tr class="accordion">
-            <input type="checkbox" id="accordion-${item._source.doc.match_title}" name="accordion-checkbox" hidden/>
-        `;
-        rows += `<td>${item._source.doc.match_title}...</td>`;
-        rows += `<td>${item._source.doc.organisation}</td>`;
+        rows += `<tr class="accordion-row" id="accordion-row-${item._source.doc.reference_id}">`;
+        rows += `<td class="accordion-arrow"><i class="icon icon-arrow-down mr-1"></i></td>`
+        rows += `<td>${item._source.doc.match_title}</td>`;
+        rows += `<td>${item._source.doc.match_publication}</td>`;
         rows += `<td>${item._source.doc.match_authors}</td>`;
         rows += `<td>${item._source.doc.match_pub_year}</td>`;
-        rows += `<td>#</td>`;
+        rows += `<td>${item._source.doc.policies.length}</td>`;
         rows += `</tr>`;
 
+        rows += `<tr class="accordion-body" id="accordion-body-${item._source.doc.reference_id}" hidden="hidden">
+                    <td class="accordion-arrow"></td>
+                    <td colspan=5 class="accordion-subtable-container">
+                    <table class="table accordion-subtable">
+                        <tr>
+                            <th>Policy Document</th>
+                            <th>Policy Organisation</th>
+                            <th>Authors</th>
+                            <th>Year of Publicaction</th>
+                        </tr>
+        `;
+        item._source.doc.policies.forEach((item) => {
+            rows += `<tr>`;
+            rows += `<td>${item.title}</td>`;
+            rows += `<td>${item.organisation}</td>`;
+            rows += `<td>${item.authors}</td>`;
+            rows += `<td>${item.year}</td>`;
+        });
+        rows += `</table></td>`
+        rows += `</tr>`;
     });
     return rows;
 }
@@ -33,6 +52,7 @@ function refreshCitations(data, currentState) {
 
     const table = document.getElementById('citations-results-tbody');
     const pages = document.getElementsByClassName('page-item');
+    const accordions = document.getElementsByClassName('accordion-row');
 
     table.innerHTML = getCitationsTableContent(data);
 
@@ -71,6 +91,21 @@ function refreshCitations(data, currentState) {
             getData('citations', currentState, refreshCitations);
         });
     };
+
+    for (let item of accordions) {
+        item.addEventListener('click', (e) => {
+            const accordionBodyId = e.currentTarget.getAttribute('id').replace('row', 'body');
+
+            let accordionBody = document.getElementById(accordionBodyId);
+
+            if (accordionBody.getAttribute('hidden')) {
+                accordionBody.removeAttribute('hidden');
+            }
+            else {
+                accordionBody.setAttribute('hidden', 'hidden');
+            }
+        });
+    }
 }
 
 

--- a/reach/web/src/js/citationsTable.js
+++ b/reach/web/src/js/citationsTable.js
@@ -22,9 +22,8 @@ function getCitationsTableContent(data) {
         rows += `<td>${item._source.doc.policies.length}</td>`;
         rows += `</tr>`;
 
-        rows += `<tr class="accordion-body" id="accordion-body-${item._source.doc.reference_id}" hidden="hidden">
-                    <td class="accordion-arrow"></td>
-                    <td colspan=5 class="accordion-subtable-container">
+        rows += `<tr class="accordion-body hidden" id="accordion-body-${item._source.doc.reference_id}">
+                    <td colspan=6 class="accordion-subtable-container">
                     <table class="table accordion-subtable">
                         <tr>
                             <th>Policy Document</th>
@@ -98,12 +97,10 @@ function refreshCitations(data, currentState) {
 
             let accordionBody = document.getElementById(accordionBodyId);
 
-            if (accordionBody.getAttribute('hidden')) {
-                accordionBody.removeAttribute('hidden');
-            }
-            else {
-                accordionBody.setAttribute('hidden', 'hidden');
-            }
+            accordionBody.classList.toggle('hidden');
+            e.currentTarget.classList.toggle('active-row');
+            e.currentTarget.firstChild.firstChild.classList.toggle('icon-arrow-down');
+            e.currentTarget.firstChild.firstChild.classList.toggle('icon-arrow-up');
         });
     }
 }

--- a/reach/web/templates/results/citations.html
+++ b/reach/web/templates/results/citations.html
@@ -143,14 +143,15 @@
                     <table class="table table-light table-hover"  id="citations-result-table">
                         <thead>
                             <tr>
-                                <th class="sort" data-sort="match_title.keyword" data-order="asc" id="active-sort">Research publication</th>
+                                <th></th>
+                                <th class="sort" data-sort="match_title.keyword" data-order="asc" id="active-sort"> <img src="/static/images/Icon_Research_24px.svg" alt="Research paper icon">Research publication</th>
                                 <th class="sort" data-sort="match_publication">Journal</th>
                                 <th class="sort" data-sort="match_authors.keyword">Author(s)</th>
                                 <th class="sort" data-sort="match_pub_year">Year of publication</th>
                                 <th>Citations in policy docs</th>
                             </tr>
                         </thead>
-                         <tbody id="citations-results-tbody">
+                        <tbody id="citations-results-tbody">
                         </tbody>
                     </table>
                 </div>

--- a/reach/web/templates/results/citations.html
+++ b/reach/web/templates/results/citations.html
@@ -144,11 +144,11 @@
                         <thead>
                             <tr>
                                 <th></th>
-                                <th class="sort" data-sort="match_title.keyword" data-order="asc" id="active-sort"> <img src="/static/images/Icon_Research_24px.svg" alt="Research paper icon">Research publication</th>
-                                <th class="sort" data-sort="match_publication">Journal</th>
-                                <th class="sort" data-sort="match_authors.keyword">Author(s)</th>
-                                <th class="sort" data-sort="match_pub_year">Year of publication</th>
-                                <th>Citations in policy docs</th>
+                                <th class="sort" data-sort="match_title.keyword" data-order="asc" id="active-sort"><span class="icn icn-research-paper"></span> Research publication <span class="icn icn-sort"></th>
+                                <th class="sort" data-sort="match_publication">Journal <span class="icn icn-sort"></span></th>
+                                <th class="sort" data-sort="match_authors.keyword">Author(s) <span class="icn icn-sort"></span></th>
+                                <th class="sort" data-sort="match_pub_year">Publication Year <span class="icn icn-sort"></span></th>
+                                <th>Citations in policy&nbspdocs</th>
                             </tr>
                         </thead>
                         <tbody id="citations-results-tbody">

--- a/reach/web/views/search.py
+++ b/reach/web/views/search.py
@@ -162,9 +162,10 @@ class CSVExport:
                 params = {
                     "term": req.params.get('term', ''),
                     "fields": ','.join([
-                        'match_title',
-                        'policy_title',
                         'organisation',
+                        'match_title',
+                        'policies.title',
+                        'policies.organisation',
                         'match_source',
                         'match_publication',
                         'match_authors'
@@ -173,7 +174,12 @@ class CSVExport:
             else:
                 params = {
                     "term": req.params.get('term', ''),
-                    "fields": "text,organisation",
+                    "fields": ','.join([
+                        'title',
+                        'text',
+                        'organisation',
+                        'authors',
+                    ]),
                 }
 
             status, response = _search_es(
@@ -234,6 +240,12 @@ class FulltextPage(template.TemplateResource):
         self.es = es
         self.es_index = es_index
         self.es_explain = es_explain
+        self.search_fields = ','.join([
+            'title',
+            'text',
+            'organisation',
+            'authors',
+        ])
 
         super(FulltextPage, self).__init__(template_dir, context)
 
@@ -241,7 +253,7 @@ class FulltextPage(template.TemplateResource):
         if req.params:
             params = {
                 "term": req.params.get('term', ''),  # es returns none on empty
-                "fields": "text,organisation",  # search_es is expects a str
+                "fields": self.search_fields,  # search_es is expects a str
                 "size": int(req.params.get('size', 1)),
                 "sort": "organisation",
             }
@@ -289,8 +301,8 @@ class CitationPage(template.TemplateResource):
         self.es_explain = es_explain
         self.search_fields = ','.join([
             'match_title',
-            'policy_title',
-            'organisation',
+            'policies.title',
+            'policies.organisation',
             'match_source',
             'match_publication',
             'match_authors'

--- a/reach/web/views/search.py
+++ b/reach/web/views/search.py
@@ -9,7 +9,7 @@ from reach.web.views import template
 from reach.web import api
 
 
-def _search_policy(es, es_index, params, explain=False):
+def _search_es(es, es_index, params, explain=False):
         """Run a search on the elasticsearch database.
 
         Args:
@@ -25,7 +25,7 @@ def _search_policy(es, es_index, params, explain=False):
         """
         try:
             fields = params.get('fields', '').split(',')
-            size = params.get('size', 100)
+            size = params.get('size', 25)
             es.cluster.health(wait_for_status='yellow')
 
             es_body = {
@@ -45,62 +45,6 @@ def _search_policy(es, es_index, params, explain=False):
             if params.get('sort'):
                 es_body['sort'] = {
                     f"doc.{params.get('sort')}": params.get('order', 'desc')
-                }
-
-            return True, es.search(
-                index=es_index,
-                body=json.dumps(es_body),
-                explain=explain
-            )
-
-        except ConnectionError:
-            message = 'Could not join the elasticsearch server.'
-            raise falcon.HTTPServiceUnavailable(description=message)
-
-        except NotFoundError:
-            message = 'No results found.'
-            return False, {'message': message}
-
-        except Exception as e:
-            raise falcon.HTTPError(description=str(e))
-
-
-def _search_citations(es, es_index, params, explain=False):
-        """Run a search on the elasticsearch database.
-
-        Args:
-            es: An Elasticsearch active connection.
-            params: The request's parameters. Shoud include 'term' and at
-                    least a field.
-            explain: A boolean to enable|disable elasticsearch's explain.
-
-        Returns:
-            True|False: The search success status
-            es.search()|str: A dict containing the result of the search if it
-                             succeeded or a string explaining why it failed
-        """
-        try:
-            fields = params.get('fields', '').split(',')
-            size = params.get('size', 100)
-            es.cluster.health(wait_for_status='yellow')
-
-            es_body = {
-                'size': int(size),
-                'query': {
-                    'multi_match': {
-                        'query': params.get('term'),
-                        'type': "best_fields",
-                        'fields': ['.'.join(['doc', f]) for f in fields]
-                    }
-                }
-            }
-
-            if params.get('page'):
-                es_body['from'] = (int(params.get('page')) - 1) * int(size)
-
-            if params.get('sort'):
-                es_body['sort'] = {
-                    f"doc.{params.get('sort')}": params.get('order', 'asc')
                 }
 
             return True, es.search(
@@ -155,10 +99,6 @@ class SearchApi:
             req: The request passed to this controller
             resp: The reponse object to be returned
         """
-        if "citation" in self.es_index:
-            search_es = _search_citations
-        else:
-            search_es = _search_policy
 
         if req.params:
             if not req.params.get('term'):
@@ -168,7 +108,7 @@ class SearchApi:
                 })
                 resp.status = falcon.HTTP_400
 
-            status, response = search_es(
+            status, response = _search_es(
                 self.es,
                 self.es_index,
                 req.params,
@@ -221,7 +161,14 @@ class CSVExport:
             if 'citations' in self.es_index:
                 params = {
                     "term": req.params.get('term', ''),
-                    "fields": "Extracted title,Matched title,Document id",
+                    "fields": ','.join([
+                        'match_title',
+                        'policy_title',
+                        'organisation',
+                        'match_source',
+                        'match_publication',
+                        'match_authors'
+                    ]),
                 }
             else:
                 params = {
@@ -229,7 +176,7 @@ class CSVExport:
                     "fields": "text,organisation",
                 }
 
-            status, response = _search_policy(
+            status, response = _search_es(
                 self.es,
                 self.es_index,
                 params,
@@ -300,7 +247,7 @@ class FulltextPage(template.TemplateResource):
             }
 
             # Still query on the backend to ensure some results are found
-            status, response = _search_policy(
+            status, response = _search_es(
                 self.es,
                 self.es_index,
                 params,
@@ -359,7 +306,7 @@ class CitationPage(template.TemplateResource):
                 "size": int(req.params.get('size', 1)),
             }
 
-            status, response = _search_citations(
+            status, response = _search_es(
                 self.es,
                 self.es_index,
                 params,


### PR DESCRIPTION
# Description
This PR aim to bring the collapsible rows feature to Reach's web application. To provide this feature:
- Change the behaviour of the fuzzymatching task to save research papers' related policy docs in a dedicated list field (`policies`).

- Refactor the `_search_es` function, as it is not needed anymore to have two different (grouping done beforehand)

- Rewrite the JS refresh class to account for collapsible rows

- Add dedicated classes in CSS in order to match the mockups in Zepplin

## Type of change
- [x] :sparkles: New feature

# How Has This Been Tested?
`make docker-test`
Local tests with Docker (2CPU/10.5GiB/1.0GiBSwap)