### PR TITLE
Add blinker to unpinned dependecies (Fixes 329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To develop for this project, you will need:
 
 To bring up the development environment using docker:
 
-1. Set your AWS credentials into your environment. (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
+1. Set your AWS credentials into your environment. (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`). These can be added to a `.env` file which will be read by docker-compose.
 1. Build and start the env with:
     ```
     make docker-build

--- a/unpinned_requirements.txt
+++ b/unpinned_requirements.txt
@@ -1,5 +1,6 @@
 apache-airflow[crypto]
 boto3
+blinker
 cryptography
 celery
 editdistance


### PR DESCRIPTION
# Description

Adds missing `blinker` dependency to unpinned requirements which was causing #329.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix

# How Has This Been Tested?

`make test && make docker-test`

# Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
