### PR TITLE
Add Reach end-to-end evaluation to policy dag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ LATEST_TAG := latest
 VERSION := latest
 
 REFERENCE_SPLITTER_URL := https://datalabs-public.s3.eu-west-2.amazonaws.com/references_splitter/reference_splitter-2019.8.0-py3-none-any.whl
+REACH_EVALUATOR_WHEEL := reach_evaluator-2020.1.1-py3-none-any.whl
+REACH_EVALUATOR_URL := https://datalabs-public.s3.eu-west-2.amazonaws.com/reach_evaluator/$(REACH_EVALUATOR_WHEEL)
 
 #
 # reach/web
@@ -115,6 +117,7 @@ update-requirements-txt:
 		grep -v references-splitter | \
 		sed 's/airflow/airflow[celery]/' >> requirements.txt
 	echo $(REFERENCE_SPLITTER_URL) >> requirements.txt
+	echo $(REACH_EVALUATOR_URL) >> requirements.txt
 
 
 #

--- a/reach/airflow/dags/match_annotated_titles.py
+++ b/reach/airflow/dags/match_annotated_titles.py
@@ -71,7 +71,7 @@ EPMC_METADATA_KEY = '/'.join([
 #
 
 
-def create_dag_for_data_prep(dag_id, default_args):
+def create_match_dag(dag_id, default_args):
     """
     Creates a DAG that produces citations using both fuzzy and exact
     matchers.
@@ -107,11 +107,11 @@ def create_dag_for_data_prep(dag_id, default_args):
     )
 
     extractedGoldRefs >> fuzzyMatchGoldRefs
-    return fuzzyMatchGoldRefs
+    return dag
 
 
-test_dag = create_dag_for_data_prep(
-    'prepare_evaluation_data',
+matched_annotated_titles_dag = create_match_dag(
+    'match_annotated_titles',
     DEFAULT_ARGS,
 )
 

--- a/reach/airflow/dags/match_annotated_titles.py
+++ b/reach/airflow/dags/match_annotated_titles.py
@@ -1,0 +1,117 @@
+""" Matches manually annotated titles against EPMC for manual verification
+    before use for evaluation.
+"""
+
+import datetime
+from airflow import DAG
+import airflow.configuration as conf
+import airflow.utils.dates
+
+from reach.airflow.tasks import fuzzy_match_refs
+from reach.airflow.tasks import evaluator
+
+DEFAULT_ARGS = {
+    'depends_on_past': False,
+    'start_date': airflow.utils.dates.days_ago(2),
+    'retries': 0,
+    'retry_delay': datetime.timedelta(minutes=5),
+}
+
+REFERENCE_ANNOTATIONS="s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid_TITLE.jsonl.gz"
+TITLE_ANNOTATIONS = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid.jsonl.gz"
+
+#
+# Configuration & paths
+#
+
+def verify_s3_prefix():
+    reach_s3_prefix = conf.get("core", "reach_s3_prefix")
+    assert reach_s3_prefix.startswith('s3://')
+    assert not reach_s3_prefix.endswith('/')
+
+# Force verification of S3 prefix on import
+verify_s3_prefix()
+
+
+def get_es_hosts():
+    result = conf.get("core", "elasticsearch_hosts")
+    assert result
+    return [x.strip().split(':') for x in result.split(',')]
+
+
+def to_s3_output(dag, *args):
+    """ Returns the S3 URL for any output file for the DAG. """
+    components, suffix = args[:-1], args[-1]
+    path = '/'.join(components)
+    slug = '-'.join(components)
+    return (
+        '{{ conf.get("core", "reach_s3_prefix") }}'
+        '/output/%s/%s/%s%s'
+    ) % (dag.dag_id, path, slug, suffix)
+
+
+def to_s3_output_dir(dag, *args):
+    """ Returns the S3 URL for any output directory for the DAG. """
+    path = '/'.join(args)
+    slug = '-'.join(args)
+    return (
+        '{{ conf.get("core", "reach_s3_prefix") }}'
+        '/output/%s/%s/%s'
+    ) % (dag.dag_id, path, slug)
+
+
+EPMC_METADATA_KEY = '/'.join([
+    '{{ conf.get("core", "openresearch_s3_prefix") }}',
+    'output', 'open-research', 'epmc-metadata', 'epmc-metadata.json.gz'
+    ])
+
+
+#
+# Tasks within the DAG
+#
+
+
+def create_dag_for_data_prep(dag_id, default_args):
+    """
+    Creates a DAG that produces citations using both fuzzy and exact
+    matchers.
+
+    Args:
+        dag_id: dag id
+        default_args: default args for the DAG
+    """
+    dag = DAG(
+        dag_id=dag_id,
+        default_args=default_args,
+        schedule_interval=None
+    )
+
+    extractedGoldRefs = evaluator.ExtractRefsFromGoldDataOperator(
+        task_id='EvaluateExtractRefsFromGoldData',
+        refs_s3_key=REFERENCE_ANNOTATIONS,
+        titles_s3_key=TITLE_ANNOTATIONS,
+        dst_s3_key=to_s3_output(
+            dag, 'evaluation', 'extracted-gold-refs', '.json.gz'),
+        dag=dag,
+    )
+
+    fuzzyMatchGoldRefs = fuzzy_match_refs.FuzzyMatchRefsOperator(
+        task_id='EvaluateFuzzyMatchGoldRefs',
+        es_hosts=get_es_hosts(),
+        src_s3_key=extractedGoldRefs.dst_s3_key,
+        organisation='gold',
+        dst_s3_key=to_s3_output(
+            dag, 'evaluation', 'fuzzy-matched-gold-refs', '.json.gz'),
+        es_index='-'.join([dag.dag_id, 'epmc', 'metadata']),
+        dag=dag,
+    )
+
+    extractedGoldRefs >> fuzzyMatchGoldRefs
+    return fuzzyMatchGoldRefs
+
+
+test_dag = create_dag_for_data_prep(
+    'prepare_evaluation_data',
+    DEFAULT_ARGS,
+)
+

--- a/reach/airflow/dags/policy.py
+++ b/reach/airflow/dags/policy.py
@@ -188,7 +188,7 @@ def org_fuzzy_match(dag, organisation, item_limits, parsePdf, esIndexPublication
     return esIndexFuzzyMatched, fuzzyMatchRefs
 
 
-def evaluate_matches(dag, organisation):
+def evaluate_matches(dag, fuzzyMatchRefs):
     """
     Evaluate matches against a manually labelled gold dataset
     """
@@ -216,7 +216,7 @@ def evaluate_matches(dag, organisation):
         task_id='EvaluateFuzzyMatchGoldRefs',
         es_hosts=get_es_hosts(),
         src_s3_key=extractedGoldRefs.dst_s3_key,
-        organisation=organisation,
+        organisation='gold',
         dst_s3_key=to_s3_output(
             dag, 'evaluation', 'fuzzy-matched-gold-refs', '.json.gz'),
         es_index='-'.join([dag.dag_id, 'epmc', 'metadata']),
@@ -232,8 +232,7 @@ def evaluate_matches(dag, organisation):
         dag=dag,
     )
 
-    combineReachFuzzyMatchRefs >> extractedGoldRefs >> fuzzyMatchGoldRefs >> evaluateRefs
-    return evaluateRefs
+    fuzzyMatchRefs >> combineReachFuzzyMatchRefs >> extractedGoldRefs >> fuzzyMatchGoldRefs >> evaluateRefs
 
 
 def create_org_pipeline_fuzzy_match(dag, organisation, item_limits, spider_years,
@@ -249,16 +248,15 @@ def create_org_pipeline_fuzzy_match(dag, organisation, item_limits, spider_years
     """
 
     parsePdf = org_refs(dag, organisation, item_limits, spider_years)
-    esIndexFuzzyMatched = org_fuzzy_match(
+    esIndexFuzzyMatched, fuzzyMatchRefs = org_fuzzy_match(
         dag, organisation, item_limits, parsePdf, esIndexPublications)
-    evaluatedMatches = evaluate_matches(dag, organisation)
 
-    return parsePdf, esIndexFuzzyMatched
+    return parsePdf, esIndexFuzzyMatched, fuzzyMatchRefs
 
 def create_org_pipeline_exact_match(dag, organisation, item_limits,
                                     spider_years, parsePdf=None,
                                     esIndexFullTexts=None):
-    """ Creates all tasks needed for producing exact matched citatinos
+    """ Creates all tasks needed for producing exact matched citations
     for a single organisation::
 
         Spider -> ParsePdf
@@ -309,13 +307,21 @@ def create_dag_fuzzy_match(dag_id, default_args, spider_years,
         schedule_interval='0 0 * * 0,3'
     )
     esIndexPublications = es_index_publications(dag, item_limits)
+    fuzzyMatchRefsOperators = []
     for organisation in ORGANISATIONS:
-        create_org_pipeline_fuzzy_match(
+        _, _, fuzzyMatchRefs = create_org_pipeline_fuzzy_match(
             dag,
             organisation,
             item_limits,
             spider_years,
             esIndexPublications)
+        fuzzyMatchRefsOperators.append(fuzzyMatchRefs)
+
+    # Run the evaluation setting all the fuzzMatchRefsOperators as upstream
+    # depdendencies.
+
+    evaluate_matches(dag, fuzzyMatchRefsOperators)
+
     return dag
 
 
@@ -338,13 +344,16 @@ def create_dag_all_match(dag_id, default_args, spider_years,
     )
     epmc_limits = ItemLimits(None, None)
     esIndexPublications = es_index_publications(dag, epmc_limits)
+    fuzzyMatchRefsOperators = []
     for organisation in ORGANISATIONS:
-        parsePdf, _ = create_org_pipeline_fuzzy_match(
+        parsePdf, _, fuzzyMatchRefs = create_org_pipeline_fuzzy_match(
             dag,
             organisation,
             item_limits,
             spider_years,
             esIndexPublications)
+
+        fuzzyMatchRefsOperators.append(fuzzyMatchRefs)
 
         create_org_pipeline_exact_match(
             dag,
@@ -353,6 +362,11 @@ def create_dag_all_match(dag_id, default_args, spider_years,
             spider_years,
             parsePdf=parsePdf,
             esIndexFullTexts=None)
+
+    # Run the evaluation setting all the fuzzMatchRefsOperators as upstream
+    # depdendencies.
+
+    evaluate_matches(dag, fuzzyMatchRefsOperators)
 
     return dag
 

--- a/reach/airflow/dags/policy.py
+++ b/reach/airflow/dags/policy.py
@@ -208,7 +208,7 @@ def evaluate_matches(dag, fuzzyMatchRefs):
         valid_s3_key=VALIDATION_DATA,
         gold_s3_key=GOLD_DATA,
         dst_s3_key=to_s3_output(
-            dag, 'evaluation', 'extract-gold-refs', '.json.gz'),
+            dag, 'evaluation', 'extracted-gold-refs', '.json.gz'),
         dag=dag,
     )
 

--- a/reach/airflow/dags/policy.py
+++ b/reach/airflow/dags/policy.py
@@ -33,6 +33,12 @@ DEFAULT_ARGS = {
     'retry_delay': datetime.timedelta(minutes=5),
 }
 
+# These are used for evaluating Reach end to end. VALIDATION_DATA is the 
+# actual validation set used in the current deep_reference_parser implementation
+# which features only reference annotation. The GOLD set features title
+# annotations. The two must be merged in order to retain the metadata which 
+# includes the doc_id.
+
 GOLD_DATA = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid_TITLE.jsonl.gz"
 VALIDATION_DATA = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid.jsonl.gz"
 

--- a/reach/airflow/tasks/evaluator.py
+++ b/reach/airflow/tasks/evaluator.py
@@ -1,0 +1,275 @@
+"""
+Operator to run the web scraper on every organisation.
+"""
+import os
+import tempfile
+import json
+import gzip
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+from reach.airflow.hook.wellcome_s3_hook import WellcomeS3Hook
+from reach.airflow.safe_import import safe_import
+from reach.sentry import report_exception
+from reach_evaluator import ReachEvaluator
+
+def _get_fuzzy_matches(s3, src_s3_dir_key, organisations):
+    """Get all the reach fuzzy matches from all organisations
+    and combine into a json.gz.
+    """
+    task = os.path.split(src_s3_dir_key)[-1]
+
+    fuzzy_matches = []
+
+    for org in organisations:
+        src_s3_key = f"{src_s3_dir_key}/{org}/{task}-{org}.json.gz"
+        with tempfile.TemporaryFile(mode='rb+') as tf:
+            valid_key = s3.get_key(src_s3_key)
+            valid_key.download_fileobj(tf)
+            tf.seek(0)
+
+            fuzzy_matches.extend(list(_yield_jsonl_from_gzip(tf)))
+
+        return fuzzy_matches
+
+def _yield_jsonl_from_gzip(fileobj):
+    """ Yield a list of dicts read from gzipped json(l)
+    """
+    with gzip.GzipFile(mode='rb', fileobj=fileobj) as f:
+        for line in f:
+            yield json.loads(line)
+
+def _get_span_text(text, span):
+    """Get the text that is demarcated by a span in a prodigy dict
+    """
+    return text[span["start"]:span["end"]]
+
+def _write_json_gz_to_s3(s3, data, key):
+    """Write a list of jsons to json.gz on s3
+    """
+    with tempfile.NamedTemporaryFile(mode='wb') as output_raw_f:
+        with gzip.GzipFile(mode='wb', fileobj=output_raw_f) as output_f:
+            for item in data:
+                output_f.write(json.dumps(item).encode('utf-8'))
+                output_f.write(b"\n")
+
+        output_raw_f.flush()
+        s3.load_file(
+            filename=output_raw_f.name,
+            key=key,
+            replace=True
+        )
+
+def _read_json_gz_from_s3(s3, key):
+    """Write a list of jsons to json.gz on s3
+    """
+    with tempfile.TemporaryFile(mode='rb+') as tf:
+        key = s3.get_key(key)
+        key.download_fileobj(tf)
+        tf.seek(0)
+
+        return list(_yield_jsonl_from_gzip(tf))
+
+
+class ExtractRefsFromGoldDataOperator(BaseOperator):
+    """Combine the original validation data and the annotation
+    (gold) data
+
+    NOTE: it may make sense to move this step elsewhere, but for
+    clarity I have included it here for now.
+    """
+
+    template_fields = (
+        'valid_s3_key',
+        'gold_s3_key',
+        'dst_s3_key',
+    )
+
+    @apply_defaults
+    def __init__(self, valid_s3_key, gold_s3_key, dst_s3_key,
+                 aws_conn_id="aws_default", *args, **kwargs):
+        """
+        """
+
+        super().__init__(*args, **kwargs)
+
+        self.valid_s3_key = valid_s3_key
+        self.gold_s3_key = gold_s3_key
+        self.dst_s3_key = dst_s3_key
+        self.aws_conn_id = aws_conn_id
+
+    @report_exception
+    def execute(self, context):
+        s3 = WellcomeS3Hook(aws_conn_id=self.aws_conn_id)
+
+        results = []
+
+        # Download and open the two annotated data files.
+
+        valid = _read_json_gz_from_s3(s3, self.valid_s3_key)
+        gold = _read_json_gz_from_s3(s3, self.gold_s3_key)
+
+        self.log.info(
+            'ExtractRefsFromGoldDataOperator read %d lines from %s',
+            len(valid),
+            self.valid_s3_key
+        )
+
+        self.log.info(
+            'ExtractRefsFromGoldDataOperator read %d lines from %s',
+            len(gold),
+            self.gold_s3_key
+        )
+
+        # Create lookup dict mapping input_hash to meta data
+
+        metas = {doc.get('_input_hash'):doc.get('meta') for doc in valid}
+        annotated_with_meta = []
+
+        for doc in gold:
+            doc["meta"] = metas.get(doc['_input_hash'])
+            annotated_with_meta.append(doc)
+
+        # Extract the "Title" and "document_id" from the annotated references
+
+        annotated_titles = []
+
+        for doc in annotated_with_meta:
+            doc_hash = None
+            meta = doc.get("meta", dict())
+
+            # Get metadata if it exists (this will contain the document hash -
+            # the unique id for the downloaded document assigned by Reach.
+
+            if meta:
+                doc_hash = meta.get("doc_hash")
+            spans = doc.get("spans")
+
+            # Get spans, and create references from them. Note that these spans
+            # need to be BI_TITLE, BE_TITLE, i.e. reference level spans, not
+            # individual token level spans!
+
+            if spans:
+                for span in spans:
+                    annotated_titles.append(
+                        {
+                            "document_id": doc_hash,
+                            "Title": _get_span_text(doc["text"], span)
+                        }
+                    )
+
+        _write_json_gz_to_s3(s3, annotated_titles, key=self.dst_s3_key)
+
+        self.log.info(
+            'ExtractRefsFromGoldDataOperator wrote %d lines to %s.',
+            len(annotated_titles),
+            self.dst_s3_key
+        )
+
+        self.log.info(
+            'ExtractRefsFromGoldDataOperator: Done extracting refs from '
+            'annotated data.'
+        )
+
+
+class EvaluateOperator(BaseOperator):
+    """
+    Take the output of fuzz-matched-refs operator and evaluates the results
+    against a manually labelled gold dataset, returning results in a json
+    to s3.
+
+    Args:
+        src_s3_key: S3 URL for input
+        dst_s3_key: S3 URL for output
+    """
+
+    template_fields = (
+        'gold_s3_key',
+        'reach_s3_key',
+        'dst_s3_key',
+    )
+
+    @apply_defaults
+    def __init__(self, gold_s3_key, reach_s3_key, dst_s3_key, aws_conn_id='aws_default', *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.gold_s3_key = gold_s3_key
+        self.reach_s3_key = reach_s3_key
+        self.dst_s3_key = dst_s3_key
+        self.aws_conn_id = aws_conn_id
+
+    @report_exception
+    def execute(self, context):
+
+        s3 = WellcomeS3Hook(aws_conn_id=self.aws_conn_id)
+
+        results = []
+
+        # Read data from S3
+        gold = _read_json_gz_from_s3(s3, self.gold_s3_key)
+        reach = _read_json_gz_from_s3(s3, self.reach_s3_key)
+
+        evaluator = ReachEvaluator(gold, reach)
+        eval_results = evaluator.eval()
+
+        # Add additional metadata
+
+        eval_results["gold_refs"] = self.gold_s3_key
+        eval_results["reach_refs"] = self.reach_s3_key
+
+        # Write the results to S3
+        _write_json_gz_to_s3(s3, [eval_results], key=self.dst_s3_key)
+
+        self.log.info(
+            'EvaluateOperator: Finished Evaluating Reach matches'
+        )
+
+class CombineReachFuzzyMatchesOperator(BaseOperator):
+    """ Combine all Reach fuzzy matches into a single file
+    """
+
+    template_fields = (
+        'organisations',
+        'src_s3_dir_key',
+        'dst_s3_key',
+    )
+
+    @apply_defaults
+    def __init__(self, organisations, src_s3_dir_key, dst_s3_key,
+                 aws_conn_id="aws_default", *args, **kwargs):
+        """
+        """
+
+        super().__init__(*args, **kwargs)
+
+        self.organisations = organisations
+        self.src_s3_dir_key = src_s3_dir_key
+        self.dst_s3_key = dst_s3_key
+        self.aws_conn_id = aws_conn_id
+
+    @report_exception
+    def execute(self, context):
+        s3 = WellcomeS3Hook(aws_conn_id=self.aws_conn_id)
+
+        fuzzy_matches = _get_fuzzy_matches(s3,
+            self.src_s3_dir_key, self.organisations)
+
+        self.log.info(
+            'CombineReachFuzzyMatchesOperator: read %d lines from %s files',
+            len(fuzzy_matches),
+            len(self.organisations),
+            )
+
+        # Write the results to S3
+
+        _write_json_gz_to_s3(s3, fuzzy_matches, key=self.dst_s3_key)
+
+        self.log.info(
+            'CombineReachFuzzyMatchesOperator: wrote %d lines to %s.',
+            len(fuzzy_matches),
+            self.dst_s3_key
+        )
+        self.log.info(
+            'CombineReachFuzzyMatchesOperator: Done combining reach fuzzy matches.'
+        )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,4 +126,5 @@ zope.deprecation==4.4.0
 zope.interface==4.6.0
 blinker>=1.1
 https://datalabs-public.s3.eu-west-2.amazonaws.com/references_splitter/reference_splitter-2019.8.0-py3-none-any.whl
+https://datalabs-public.s3.eu-west-2.amazonaws.com/reach_evaluator/reach_evaluator-2020.1.1-py3-none-any.whl
 


### PR DESCRIPTION
# Description

Adds a series of tasks required to complete an end-to-end evaluation of reach by comparing the results from the policy dag with manually labelled validation (gold) data (https://trello.com/c/BD44uSl6/922-add-end-to-end-evaluation-to-airflow-policy-dag).

Two tasks are added to the existing `policy` and `policy-test` dags yielding the following dags:

`policy`:
![image](https://user-images.githubusercontent.com/4583655/72911098-44bd7d80-3d18-11ea-8ec2-4461616eca1b.png)

`policy-test`:
![image](https://user-images.githubusercontent.com/4583655/72911422-cf05e180-3d18-11ea-8845-b95104124a55.png)


An additional dag (`match_annotated_titles`) is also added to ensure that the same logic for matching references found by reach can also be used for manual labelling. The output of this dag would then be manually verified, and uploaded to s3 where it can be accessed by the `policy` and `policy-test` by `evaluator.EvaluateOperator()`. The `match_annotated_titles` dag looks like:

![image](https://user-images.githubusercontent.com/4583655/72911391-bf869880-3d18-11ea-95f2-dbd9416b3c81.png)

NOTE: There remains an issue with fuzzy matching the gold labelled data against EPMC, which is hard to debug without having clean data. I will address this in a future PR, and it won't affect the functionality of this PR, just the accuracy.

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?

* `make docker-test`
* Each airflow component tested independently with `airflow test`
* Run policy-test dag on local machine


# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes