### PR TITLE
airflow: Update a logging output to reference correct key name

### DIFF
--- a/reach/airflow/tasks/fuzzy_match_refs.py
+++ b/reach/airflow/tasks/fuzzy_match_refs.py
@@ -64,7 +64,7 @@ class ElasticsearchFuzzyMatcher:
             logger.info(
                 'ElasticsearchFuzzyMatcher.match: '
                 'orig-length=%d doc-id=%s truncated-title=%r',
-                title_len, reference['Document id'], title
+                title_len, reference.get('document_id', "Unkown ID"), title
             )
 
         body = {


### PR DESCRIPTION
# Description

Fixes an issues where a logging call is referencing an incorrect key value.

Issue was raised from alert manager

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [ ] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

`make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
