### PR TITLE
Add a way to query multiple terms/fields to Reach API

### DIFF
--- a/reach/web/src/js/resultsCommon.js
+++ b/reach/web/src/js/resultsCommon.js
@@ -79,7 +79,7 @@ export function getData(type, body, callback) {
     let xhr = new XMLHttpRequest();
 
     let url = `/api/search/${type}`
-              + `?term=${body.term}`
+              + `?terms=${body.term}`
               + `&fields=${body.fields}`
               + `&size=${body.size}`
               + `&sort=${body.sort}`

--- a/reach/web/templates/results/citations.html
+++ b/reach/web/templates/results/citations.html
@@ -45,7 +45,7 @@
             <div class="column col-6 col-md-12">
                 <form action="/search/citations">
                     <div class="input-group">
-                      <input type="text" class="form-input input-xl" placeholder="Search" name="term" id="search-term" value="{{ term }}">
+                      <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term" value="{{ terms }}">
                       <button type="submit" class="btn btn-primary input-group-btn input-btn-xl">Discover citations <span class="icn icn-search"></span></button>
                     </div>
                 </form>

--- a/reach/web/templates/results/policy-docs.html
+++ b/reach/web/templates/results/policy-docs.html
@@ -45,7 +45,7 @@
             <div class="column col-6 col-md-12">
                 <form action="/search/policy-docs">
                     <div class="input-group">
-                      <input type="text" class="form-input input-xl" placeholder="Search" name="term" id="search-term" value="{{ term }}">
+                      <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term" value="{{ term }}">
                       <button type="submit" class="btn btn-primary input-group-btn input-btn-xl">Browse policy documents <span class="icn icn-search"></span></button>
                     </div>
                 </form>

--- a/reach/web/templates/search/citations.html
+++ b/reach/web/templates/search/citations.html
@@ -53,7 +53,7 @@
         <p class="form-label">Search by Reseach Publication, journal, author or year of publication</p>
         <form action="/search/citations">
           <div class="input-group">
-            <input type="text" class="form-input input-xl" placeholder="Search" name="term" id="search-term">
+            <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term">
             <button type="submit" class="btn btn-primary input-btn-xl input-group-btn">Discover citations <span class="icn icn-search"></span></button>
           </div>
         </form>

--- a/reach/web/templates/search/policy-docs.html
+++ b/reach/web/templates/search/policy-docs.html
@@ -53,7 +53,7 @@
         <p class="form-label">Search by publication title, journal, author or year of publication</p>
         <form action="/search/policy-docs">
           <div class="input-group">
-            <input type="text" class="form-input input-xl" placeholder="Search" name="term" id="search-term">
+            <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term">
             <button type="submit" class="btn btn-primary input-btn-xl input-group-btn">Browse policy documents <span class="icn icn-search"></span></button>
           </div>
         </form>

--- a/reach/web/tests/test_search_api.py
+++ b/reach/web/tests/test_search_api.py
@@ -1,0 +1,46 @@
+import json
+
+from reach.web.views import search
+
+
+VALID_BODY = json.dumps({
+    "size": 25,
+    "query": {
+        "bool": {
+            "should": [
+                {"terms": {"doc.text": ["bar", "baz"]}},
+                {"terms": {"doc.title": ["foo"]}},
+                {"terms": {"doc.organisation": ["nice"]}},
+                {"terms": {"doc.authors": ["J.Doe"]}}
+            ],
+            "minimum_should_match": 1
+        }
+    },
+    "sort": {"doc.organisation": "asc"}
+})
+
+
+def test_query_builder():
+    """Tests that the query builder builds queries the right way."""
+
+    params = {
+        "terms": ','.join([
+            "bar",
+            "foo",
+            "baz",
+            "nice",
+            "J.Doe",
+        ]),
+        "fields": ','.join([
+            "text",
+            "title",
+            "text",
+            "organisation",
+            "authors",
+        ]),
+        "sort": "organisation"
+    }
+
+    search_body = search._build_es_query(params)
+
+    assert json.dumps(search_body) == VALID_BODY


### PR DESCRIPTION
# Description

This PR aims to improve the search feature in Reach by adding a way to search for multiple terms in multiple fields in the form of comma separated parameters (e.g. `terms=malaria,dog,foo&fields=title,title,text`).

It also splits the query building step from the actual query to ES and include a new test for this query building method.

This is meant to fix #328 .

What's not in this PR:
  - Related frontend is still using the one term -> all fields style query (some ajustment have been made to keep it working)
  - API documentation (to come next in a follow up PR)

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?
`make docker-test`
Local runs on Docker with 2CPU/10.5GiB/1GiBSwap
