### PR TITLE
Pdf metadata encoding Fix #363

### DIFF
--- a/reach/pdf_parser/pdf_parse.py
+++ b/reach/pdf_parser/pdf_parse.py
@@ -59,7 +59,8 @@ def get_pdf_metadata(document):
     # regardless of metadata problems
     if result.returncode == 0:
         # info scrape succeeded
-        string_data = result.stdout.decode("utf-8")
+        # skip any non-unicode characters
+        string_data = result.stdout.decode("utf-8", 'ignore')
         data = {}
         for line in string_data.splitlines():
             if ":" in line:

--- a/reach/pdf_parser/pdf_parse.py
+++ b/reach/pdf_parser/pdf_parse.py
@@ -65,7 +65,7 @@ def get_pdf_metadata(document):
         for line in string_data.splitlines():
             if ":" in line:
                 key, value = [x.strip() for x in line.split(":", 1)]
-                data[key] = value
+                data[key.lower()] = value
 
         # Massage this into a better format
         for key, value in data.items():


### PR DESCRIPTION
# Description

Aiming to fix issue #363, where metadata cannot be decoded from unicode. After reviewing catching the error and trying to decode with an alternate encoding, felt the best call was to just skip the characters that can't be decoded. Shouldn't raise any exceptions and therefore shouldn't disrupt the DAG at all. 

Also, set metadata keys to be lowercase so 'title' and 'Title' can both be extracted.

## Type of change

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

Tested this locally on a handful of PDFs. 

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
