### PR TITLE
Scraper list index Fix #353

### DIFF
--- a/reach/scraper/wsf_scraping/spiders/base_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/base_spider.py
@@ -163,7 +163,7 @@ class BaseSpider(scrapy.Spider):
         disposition_name = None
         cd_header = response.headers.get("Content-Disposition", None)
         if cd_header:
-            cd_items = [x.split(b"=") for x in cd_header.split(b';')[1:]]
+            cd_items = [x.split(b"=") for x in cd_header.split(b';')[1:] if b"=" in x]
             cd_items = dict((item[0].lower(), item[1] or None) for item in cd_items if item[0] is not None)
             disposition_name = cd_items.get(b"name", None)
             if disposition_name is None:

--- a/reach/scraper/wsf_scraping/spiders/base_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/base_spider.py
@@ -164,7 +164,7 @@ class BaseSpider(scrapy.Spider):
         cd_header = response.headers.get("Content-Disposition", None)
         if cd_header:
             cd_items = [x.split(b"=") for x in cd_header.split(b';')[1:] if b"=" in x]
-            cd_items = dict((item[0].lower(), item[1] or None) for item in cd_items if item[0] is not None)
+            cd_items = dict((item[0].lower(), item[1]) for item in cd_items if item[0] is not None)
             disposition_name = cd_items.get(b"name", None)
             if disposition_name is None:
                 disposition_name = cd_items.get(b"filename", None)

--- a/reach/scraper/wsf_scraping/spiders/base_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/base_spider.py
@@ -164,7 +164,7 @@ class BaseSpider(scrapy.Spider):
         cd_header = response.headers.get("Content-Disposition", None)
         if cd_header:
             cd_items = [x.split(b"=") for x in cd_header.split(b';')[1:] if b"=" in x]
-            cd_items = dict((item[0].lower(), item[1]) for item in cd_items if item[0] is not None)
+            cd_items = dict((item[0].strip().lower(), item[1]) for item in cd_items if item[0] is not None)
             disposition_name = cd_items.get(b"name", None)
             if disposition_name is None:
                 disposition_name = cd_items.get(b"filename", None)


### PR DESCRIPTION
# Description

Aimed to fix #353. List index out of range was being caused in this case by a header that ended with a semi-colon. 

```
b'attachment; filename="CD_OFSM-ECS.pdf";'
```

When split on the semi-colon this left a list with no '=', which then could obviously not be split into a sublist of two items. Fixed this by checking that each item contains an '=' before that second split.

Also, removed the `item[1] or None` on line 167 as this wasn't returning None when the index didn't exist. 

Finally, I also stripped the item[0] key as in the same example it was set to ' filename' with that whitespace stopping the next few lines from extracting the filename.  

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

Tested locally and ran `make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
