### PR TITLE
Fix issues in gold reference extraction (Fix #367)

### DIFF
--- a/reach/airflow/dags/match_annotated_titles.py
+++ b/reach/airflow/dags/match_annotated_titles.py
@@ -17,8 +17,8 @@ DEFAULT_ARGS = {
     'retry_delay': datetime.timedelta(minutes=5),
 }
 
-REFERENCE_ANNOTATIONS="s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid_TITLE.jsonl.gz"
-TITLE_ANNOTATIONS = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid.jsonl.gz"
+TITLE_ANNOTATIONS="s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid_TITLE.jsonl.gz"
+REFERENCE_ANNOTATIONS = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid.jsonl.gz"
 
 # dag.id of dag which produced the EPMC ES Index
 ES_INDEX="policy"

--- a/reach/airflow/dags/match_annotated_titles.py
+++ b/reach/airflow/dags/match_annotated_titles.py
@@ -94,7 +94,7 @@ def create_match_dag(dag_id, default_args):
         refs_s3_key=REFERENCE_ANNOTATIONS,
         titles_s3_key=TITLE_ANNOTATIONS,
         dst_s3_key=to_s3_output(
-            dag, 'evaluation', 'extracted-gold-refs', '.json.gz'),
+            dag, 'extracted-gold-refs', '.json.gz'),
         dag=dag,
     )
 
@@ -104,7 +104,7 @@ def create_match_dag(dag_id, default_args):
         src_s3_key=extractedGoldRefs.dst_s3_key,
         organisation='gold',
         dst_s3_key=to_s3_output(
-            dag, 'evaluation', 'fuzzy-matched-gold-refs', '.json.gz'),
+            dag, 'fuzzy-matched-gold-refs', '.json.gz'),
         es_index='-'.join([ES_INDEX, 'epmc', 'metadata']),
         dag=dag,
     )

--- a/reach/airflow/dags/match_annotated_titles.py
+++ b/reach/airflow/dags/match_annotated_titles.py
@@ -85,8 +85,8 @@ def create_match_dag(dag_id, default_args):
         schedule_interval=None
     )
 
-    matchedAnnotations = evaluator.AddDocidToTitleAnnotations(
-        task_id='EvaluateMatchAnnotations',
+    addedDocidToTitleAnnotations = evaluator.AddDocidToTitleAnnotations(
+        task_id='EvaluateAddDocidToTitleAnnotations',
         refs_s3_key=from_s3_input(
             'data',
             '2019.10.8_valid.jsonl.gz',
@@ -102,7 +102,7 @@ def create_match_dag(dag_id, default_args):
 
     extractedGoldRefs = evaluator.ExtractRefsFromGoldDataOperator(
         task_id='EvaluateExtractRefsFromGoldData',
-        src_s3_key=matchedAnnotations.dst_s3_key,
+        src_s3_key=addedDocidToTitleAnnotations.dst_s3_key,
         dst_s3_key=to_s3_output(
             dag, 'extracted-gold-refs', '.json.gz'),
         dag=dag,
@@ -119,7 +119,7 @@ def create_match_dag(dag_id, default_args):
         dag=dag,
     )
 
-    matchedAnnotations >> extractedGoldRefs >> fuzzyMatchGoldRefs
+    addedDocidToTitleAnnotations >> extractedGoldRefs >> fuzzyMatchGoldRefs
     return dag
 
 

--- a/reach/airflow/dags/match_annotated_titles.py
+++ b/reach/airflow/dags/match_annotated_titles.py
@@ -20,6 +20,9 @@ DEFAULT_ARGS = {
 REFERENCE_ANNOTATIONS="s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid_TITLE.jsonl.gz"
 TITLE_ANNOTATIONS = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_valid.jsonl.gz"
 
+# dag.id of dag which produced the EPMC ES Index
+ES_INDEX="policy"
+
 #
 # Configuration & paths
 #
@@ -102,7 +105,7 @@ def create_match_dag(dag_id, default_args):
         organisation='gold',
         dst_s3_key=to_s3_output(
             dag, 'evaluation', 'fuzzy-matched-gold-refs', '.json.gz'),
-        es_index='-'.join([dag.dag_id, 'epmc', 'metadata']),
+        es_index='-'.join([ES_INDEX, 'epmc', 'metadata']),
         dag=dag,
     )
 

--- a/reach/airflow/dags/policy.py
+++ b/reach/airflow/dags/policy.py
@@ -33,7 +33,7 @@ DEFAULT_ARGS = {
     'retry_delay': datetime.timedelta(minutes=5),
 }
 
-GOLD_DATA = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8-fuzzy-matched-gold-refs-manually-verified.jsonl"
+GOLD_DATA = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8-fuzzy-matched-gold-refs-manually-verified.jsonl.gz"
 
 #
 # FuzzyMatch settings

--- a/reach/airflow/dags/policy.py
+++ b/reach/airflow/dags/policy.py
@@ -33,7 +33,7 @@ DEFAULT_ARGS = {
     'retry_delay': datetime.timedelta(minutes=5),
 }
 
-GOLD_DATA = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_gold_matched_references_snake.jsonl"
+GOLD_DATA = "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8-fuzzy-matched-gold-refs-manually-verified.jsonl"
 
 #
 # FuzzyMatch settings

--- a/reach/airflow/tasks/evaluator.py
+++ b/reach/airflow/tasks/evaluator.py
@@ -197,16 +197,20 @@ class ExtractRefsFromGoldDataOperator(BaseOperator):
                 if doc_hash:
                     spans = doc.get("spans")
 
-                    # Get spans, and create references from them. Note that 
+                    # Get spans, and create references from them. Note that
                     # these spans need to be TITLE, i.e. reference level spans,
-                    # not individual token level spans!
+                    # not individual token level spans! This will create a 
+                    # dict index by title with a list of doc_hashes in which
+                    # those titles were found.
 
                     if spans:
                         for span in spans:
+                            title = _get_span_text(doc["text"], span)
                             annotated_titles.append(
                                 {
                                     "document_id": doc_hash,
-                                    "Title": _get_span_text(doc["text"], span)
+                                    "Title": _get_span_text(doc["text"], span),
+                                    "metadata": {"file_hash": doc_hash}
                                 }
                             )
 

--- a/reach/airflow/tasks/evaluator.py
+++ b/reach/airflow/tasks/evaluator.py
@@ -209,8 +209,9 @@ class ExtractRefsFromGoldDataOperator(BaseOperator):
                             annotated_titles.append(
                                 {
                                     "document_id": doc_hash,
-                                    "Title": _get_span_text(doc["text"], span),
-                                    "metadata": {"file_hash": doc_hash}
+                                    "Title": title,
+                                    "metadata": {"file_hash": doc_hash},
+                                    "reference_id": hash(title)
                                 }
                             )
 

--- a/reach/airflow/tasks/evaluator.py
+++ b/reach/airflow/tasks/evaluator.py
@@ -247,12 +247,13 @@ class EvaluateOperator(BaseOperator):
     )
 
     @apply_defaults
-    def __init__(self, gold_s3_key, reach_s3_key, dst_s3_key, aws_conn_id='aws_default', *args, **kwargs):
+    def __init__(self, gold_s3_key, reach_s3_key, dst_s3_key, aws_conn_id='aws_default', reach_params=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.gold_s3_key = gold_s3_key
         self.reach_s3_key = reach_s3_key
         self.dst_s3_key = dst_s3_key
         self.aws_conn_id = aws_conn_id
+        self.reach_params = reach_params
 
     @report_exception
     def execute(self, context):
@@ -272,6 +273,7 @@ class EvaluateOperator(BaseOperator):
 
         eval_results["gold_refs"] = self.gold_s3_key
         eval_results["reach_refs"] = self.reach_s3_key
+        eval_results['reach_params'] = self.reach_params
 
         # Write the results to S3
         _write_json_gz_to_s3(s3, [eval_results], key=self.dst_s3_key)

--- a/reach/airflow/tasks/evaluator.py
+++ b/reach/airflow/tasks/evaluator.py
@@ -185,20 +185,30 @@ class ExtractRefsFromGoldDataOperator(BaseOperator):
 
             if meta:
                 doc_hash = meta.get("doc_hash")
-            spans = doc.get("spans")
 
-            # Get spans, and create references from them. Note that these spans
-            # need to be BI_TITLE, BE_TITLE, i.e. reference level spans, not
-            # individual token level spans!
+                # Only add the reference if there is a doc_hash, if not the
+                # reference is not useful for evaluation. This may occur when
+                # it was not possible to reconcile the _input_hash from the
+                # title annotation with the _input_hash from the reference
+                # annotation which contains the full metadata. Going forward
+                # this should not occur if the examples annotated for titles
+                # are drawn from those annotated for references.
 
-            if spans:
-                for span in spans:
-                    annotated_titles.append(
-                        {
-                            "document_id": doc_hash,
-                            "Title": _get_span_text(doc["text"], span)
-                        }
-                    )
+                if doc_hash:
+                    spans = doc.get("spans")
+
+                    # Get spans, and create references from them. Note that 
+                    # these spans need to be TITLE, i.e. reference level spans,
+                    # not individual token level spans!
+
+                    if spans:
+                        for span in spans:
+                            annotated_titles.append(
+                                {
+                                    "document_id": doc_hash,
+                                    "Title": _get_span_text(doc["text"], span)
+                                }
+                            )
 
         _write_json_gz_to_s3(s3, annotated_titles, key=self.dst_s3_key)
 

--- a/reach/airflow/tasks/evaluator.py
+++ b/reach/airflow/tasks/evaluator.py
@@ -38,7 +38,7 @@ def _yield_jsonl_from_gzip(fileobj):
 def _get_span_text(text, span):
     """Get the text that is demarcated by a span in a prodigy dict
     """
-    return text[span["start"]:span["end"]]
+    return text[span['start']:span['end']]
 
 def _write_json_gz_to_s3(s3, data, key):
     """Write a list of jsons to json.gz on s3
@@ -47,7 +47,7 @@ def _write_json_gz_to_s3(s3, data, key):
         with gzip.GzipFile(mode='wb', fileobj=output_raw_f) as output_f:
             for item in data:
                 output_f.write(json.dumps(item).encode('utf-8'))
-                output_f.write(b"\n")
+                output_f.write(b'\n')
 
         output_raw_f.flush()
         s3.load_file(
@@ -82,7 +82,7 @@ class AddDocidToTitleAnnotations(BaseOperator):
 
     @apply_defaults
     def __init__(self, refs_s3_key, titles_s3_key, dst_s3_key,
-                 aws_conn_id="aws_default", *args, **kwargs):
+                 aws_conn_id='aws_default', *args, **kwargs):
 
         super().__init__(*args, **kwargs)
 
@@ -120,7 +120,7 @@ class AddDocidToTitleAnnotations(BaseOperator):
         annotated_with_meta = []
 
         for doc in titles:
-            doc["meta"] = metas.get(doc['_input_hash'])
+            doc['meta'] = metas.get(doc['_input_hash'])
             annotated_with_meta.append(doc)
 
         _write_json_gz_to_s3(s3, annotated_with_meta, key=self.dst_s3_key)
@@ -147,7 +147,7 @@ class ExtractRefsFromGoldDataOperator(BaseOperator):
     )
 
     @apply_defaults
-    def __init__(self, src_s3_key, dst_s3_key, aws_conn_id="aws_default", 
+    def __init__(self, src_s3_key, dst_s3_key, aws_conn_id='aws_default', 
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -178,13 +178,13 @@ class ExtractRefsFromGoldDataOperator(BaseOperator):
 
         for doc in annotated_with_meta:
             doc_hash = None
-            meta = doc.get("meta", dict())
+            meta = doc.get('meta', dict())
 
             # Get metadata if it exists (this will contain the document hash -
             # the unique id for the downloaded document assigned by Reach.
 
             if meta:
-                doc_hash = meta.get("doc_hash")
+                doc_hash = meta.get('doc_hash')
 
                 # Only add the reference if there is a doc_hash, if not the
                 # reference is not useful for evaluation. This may occur when
@@ -195,7 +195,7 @@ class ExtractRefsFromGoldDataOperator(BaseOperator):
                 # are drawn from those annotated for references.
 
                 if doc_hash:
-                    spans = doc.get("spans")
+                    spans = doc.get('spans')
 
                     # Get spans, and create references from them. Note that
                     # these spans need to be TITLE, i.e. reference level spans,
@@ -205,13 +205,13 @@ class ExtractRefsFromGoldDataOperator(BaseOperator):
 
                     if spans:
                         for span in spans:
-                            title = _get_span_text(doc["text"], span)
+                            title = _get_span_text(doc['text'], span)
                             annotated_titles.append(
                                 {
-                                    "document_id": doc_hash,
-                                    "Title": title,
-                                    "metadata": {"file_hash": doc_hash},
-                                    "reference_id": hash(title)
+                                    'document_id': doc_hash,
+                                    'Title': title,
+                                    'metadata': {'file_hash': doc_hash},
+                                    'reference_id': hash(title)
                                 }
                             )
 
@@ -271,8 +271,8 @@ class EvaluateOperator(BaseOperator):
 
         # Add additional metadata
 
-        eval_results["gold_refs"] = self.gold_s3_key
-        eval_results["reach_refs"] = self.reach_s3_key
+        eval_results['gold_refs'] = self.gold_s3_key
+        eval_results['reach_refs'] = self.reach_s3_key
         eval_results['reach_params'] = self.reach_params
 
         # Write the results to S3
@@ -294,7 +294,7 @@ class CombineReachFuzzyMatchesOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self, organisations, src_s3_dir_key, dst_s3_key,
-                 aws_conn_id="aws_default", *args, **kwargs):
+                 aws_conn_id='aws_default', *args, **kwargs):
 
         super().__init__(*args, **kwargs)
 

--- a/reach/airflow/tasks/fuzzy_match_refs.py
+++ b/reach/airflow/tasks/fuzzy_match_refs.py
@@ -144,14 +144,11 @@ class FuzzyMatchRefsOperator(BaseOperator):
         'dst_s3_key'
     )
 
-    SHOULD_MATCH_THRESHOLD = 80
-    SCORE_THRESHOLD = 50
-
     @apply_defaults
     def __init__(self, es_hosts, src_s3_key, dst_s3_key, es_index,
-                 score_threshold=SCORE_THRESHOLD,
+                 score_threshold=50,
                  organisation=None,
-                 should_match_threshold=SHOULD_MATCH_THRESHOLD,
+                 should_match_threshold=80,
                  aws_conn_id='aws_default', *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Fixes issues with the end to end evaluation introduce in #341, primarily documented in #367. The main changes this PR introduces are:

* Splits `EvaluateExtractRegsFromGoldData` into to separate tasks for easier debugging.
* References found in the manually tagged data that cannot be pinned to a document id will be discarded for the purposes of the end to end evaluation.
* Moved specification of elastic search parameters to the policy dag specification so that these can be passed to the `EvaluateOperator` and recorded for comparison with results.
* Solves most pressing issue with matches differing from local runs (#367) by creating a dummy `reference_id` based on a hash of the title. Future versions may allow the `reference_id` to be recreated in the annotation environment once other aspects of the reference have also been manually annotated..

## Type of change

- [x] :bug: Bug fix 
- [x] :sparkles: New feature

# How Has This Been Tested?

`match_annotated_titles` dag tested on local environment
`make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
