### PR TITLE
Fix UNICEF scraper

### DIFF
--- a/reach/scraper/tests/mock_sites/unicef/1.html
+++ b/reach/scraper/tests/mock_sites/unicef/1.html
@@ -1,11 +1,21 @@
 <!DOCTYPE html>
-<html lang="en-US" prefix="og: http://ogp.me/ns#" class="no-js" dir="ltr">
+<html lang="en-US" class="no-js" dir="ltr">
 <head>
 <title>Publications Archives - UNICEF DATA</title>
 </head>
 <body class="archive tax-resource-type term-publications term-18 template--block ">
+<div class="block--card__body__text">
 <h3>
-<a href="https://data.unicef.org/resources/youthpoll/" title="A Right to be Heard &#8211; Listening to children and young people on the move">A Right to be Heard &#8211; Listening to children and young people on the move</a>
+<a href="https://data.unicef.org/resources/including-everyone-strengthening-the-collection-and-use-of-data-about-persons-with-disabilities-in-humanitarian-situations/" title="Including Everyone: Strengthening the collection and use of data about persons with disabilities in humanitarian situations">Including Everyone: Strengthening the collection and use of data about persons with disabilities in humanitarian situations</a>
 </h3>
+</div>
+<nav class="navigation pagination" role="navigation" aria-label="Posts">
+<h2 class="screen-reader-text">Posts navigation</h2>
+<div class="nav-links"><span aria-current="page" class="page-numbers current"><span class="screen-reader-text">Page </span>1</span>
+<a class="page-numbers" href="https://data.unicef.org/resources/resource-type/publications/page/2/"><span class="screen-reader-text">Page </span>2</a>
+<span class="page-numbers dots">&hellip;</span>
+<a class="page-numbers" href="https://data.unicef.org/resources/resource-type/publications/page/10/"><span class="screen-reader-text">Page </span>10</a>
+<a class="next page-numbers" href="https://data.unicef.org/resources/resource-type/publications/page/2/">Next page</a></div>
+</nav>
 </body>
 </html>

--- a/reach/scraper/wsf_scraping/items.py
+++ b/reach/scraper/wsf_scraping/items.py
@@ -3,6 +3,7 @@ import scrapy
 
 
 class Article(scrapy.Item):
+
     def __repr__(self):
         return repr({
             'title': self.get('title'),
@@ -27,5 +28,3 @@ class Article(scrapy.Item):
     link_title = scrapy.Field()
     page_headings = scrapy.Field()
     path = scrapy.Field()
-
-

--- a/reach/scraper/wsf_scraping/spiders/base_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/base_spider.py
@@ -102,7 +102,6 @@ class BaseSpider(scrapy.Spider):
 
         return (is_pdf_type, is_octet_type)
 
-
     def _is_valid_pdf_url(self, url):
         """ Check if a URL represents a valid URL path
 
@@ -170,6 +169,9 @@ class BaseSpider(scrapy.Spider):
                 disposition_name = cd_items.get(b"filename", None)
             if disposition_name is None:
                 disposition_name = cd_items.get(b'filename*', None)
+
+        if disposition_name:
+            disposition_name = disposition_name.decode('utf-8', 'ignore')
 
         max_article = self.settings.getint('MAX_ARTICLE')
         current_item_count = self.crawler.stats.get_value('item_scraped_count')

--- a/reach/scraper/wsf_scraping/spiders/unicef_spider.py
+++ b/reach/scraper/wsf_scraping/spiders/unicef_spider.py
@@ -36,11 +36,23 @@ class UnicefSpider(BaseSpider):
         @returns requests 1
         """
 
-        for href in response.css('h3 a::attr(href)').extract():
+        for href in response.css(
+            '.block--card__body__text h3 a::attr(href)'
+        ).extract():
             yield Request(
                 url=response.urljoin(href),
                 callback=self.parse_article,
                 errback=self.on_error,
+            )
+
+        for href in response.css(
+            '.pagination .next::attr(href)'
+        ).extract():
+            yield Request(
+                url=response.urljoin(href),
+                callback=self.parse,
+                errback=self.on_error,
+                dont_filter=True,
             )
 
     def parse_article(self, response):


### PR DESCRIPTION
# Description

Fix #325 
Fix #352 as a drive-by issue

Unicef updated their design, this PR changes the scraper accordingly.
Also fix an issue with the titles gettings pulled from the headers as bytes (non-json serialisable).

## Type of change

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

Local runs of parliament scraping
`make docker-test`
