### PR TITLE
- Adds the DocumentID as a key in the scraped PDFs metadata

### DIFF
--- a/reach/scraper/wsf_scraping/items.py
+++ b/reach/scraper/wsf_scraping/items.py
@@ -28,3 +28,4 @@ class Article(scrapy.Item):
     link_title = scrapy.Field()
     page_headings = scrapy.Field()
     path = scrapy.Field()
+    did = scrapy.Field()

--- a/reach/scraper/wsf_scraping/pipelines.py
+++ b/reach/scraper/wsf_scraping/pipelines.py
@@ -3,7 +3,7 @@ import os
 import logging
 from urllib.parse import urlparse
 from scrapy.utils.project import get_project_settings
-from .file_system import S3FileSystem, LocalFileSystem, get_file_hash
+from .file_system import S3FileSystem, LocalFileSystem, get_file_hash, get_pdf_id
 from scrapy.exceptions import DropItem
 
 
@@ -86,6 +86,7 @@ class WsfScrapingPipeline(object):
                 'Empty filename, could not parse the pdf.'
             )
         item['hash'] = get_file_hash(item['pdf'])
+        item['did'] = get_pdf_id(item['pdf'])
 
         in_manifest = self.is_in_manifest(item['hash'])
 


### PR DESCRIPTION
# Description

Adds the PDF DocumentID as a key in the scraped PDFs metadata

## Type of change

Please delete options that are not relevant.

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [ ] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

`make docker-test`

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
