### PR TITLE
Fix an issue where user couldn't search multiple words

### DIFF
--- a/reach/web/tests/test_search_api.py
+++ b/reach/web/tests/test_search_api.py
@@ -3,25 +3,24 @@ import json
 from reach.web.views import search
 
 
-VALID_BODY = json.dumps({
-    "size": 25,
-    "query": {
-        "bool": {
-            "should": [
-                {"terms": {"doc.text": ["bar", "baz"]}},
-                {"terms": {"doc.title": ["foo"]}},
-                {"terms": {"doc.organisation": ["nice"]}},
-                {"terms": {"doc.authors": ["J.Doe"]}}
-            ],
-            "minimum_should_match": 1
-        }
-    },
-    "sort": {"doc.organisation": "asc"}
-})
-
-
 def test_query_builder():
     """Tests that the query builder builds queries the right way."""
+
+    valid_body = json.dumps({
+        "size": 25,
+        "query": {
+            "bool": {
+                "should": [
+                    {"terms": {"doc.text": ["bar", "baz"]}},
+                    {"terms": {"doc.title": ["foo"]}},
+                    {"terms": {"doc.organisation": ["nice"]}},
+                    {"terms": {"doc.authors": ["J.Doe"]}}
+                ],
+                "minimum_should_match": 1
+            }
+        },
+        "sort": {"doc.organisation": "asc"}
+    })
 
     params = {
         "terms": ','.join([
@@ -43,4 +42,85 @@ def test_query_builder():
 
     search_body = search._build_es_query(params)
 
-    assert json.dumps(search_body) == VALID_BODY
+    assert json.dumps(search_body) == valid_body
+
+
+def test_sentence_query_builder():
+    """Tests that the query builder builds queries the right way."""
+
+    valid_body = json.dumps({
+        "size": 25,
+        "query": {
+            "bool": {
+                "should": [
+                    {"terms": {"doc.text": ["bar", "baz", "foo", "kix"]}},
+                ],
+                "minimum_should_match": 1
+            }
+        },
+        "sort": {"doc.organisation": "asc"}
+    })
+
+    params = {
+        "terms": ','.join([
+            "bar baz foo kix",
+        ]),
+        "fields": ','.join([
+            "text",
+        ]),
+        "sort": "organisation"
+    }
+
+    assert json.dumps(search._build_es_query(params)) == valid_body
+
+
+def test_multi_sentences_query_builder():
+    """Tests that the query builder builds queries the right way."""
+
+    valid_body = json.dumps({
+        "size": 25,
+        "query": {
+            "bool": {
+                "should": [
+                    {"terms": {"doc.text": ["bar", "baz", "foo", "kix"]}},
+                    {"terms": {"doc.title": [
+                        "pizza",
+                        "celery",
+                        "brocoli",
+                        "mayo",
+                    ]}},
+                ],
+                "minimum_should_match": 1
+            }
+        },
+        "sort": {"doc.organisation": "asc"}
+    })
+
+    params = {
+        "terms": ','.join([
+            "bar baz foo kix",
+            "pizza celery brocoli mayo",
+        ]),
+        "fields": ','.join([
+            "text",
+            "title"
+        ]),
+        "sort": "organisation"
+    }
+
+    assert json.dumps(search._build_es_query(params)) == valid_body
+
+    params = {
+        "terms": ','.join([
+            "bar baz",
+            "pizza celery brocoli mayo",
+            "foo kix",
+        ]),
+        "fields": ','.join([
+            "text",
+            "title",
+            "text"
+        ]),
+        "sort": "organisation"
+    }
+    assert json.dumps(search._build_es_query(params)) == valid_body

--- a/reach/web/views/search.py
+++ b/reach/web/views/search.py
@@ -31,9 +31,9 @@ def _build_es_query(params):
     for i, fieldname in enumerate(fields):
         field = "doc.{fieldname}".format(fieldname=fieldname)
         if field in body_queries.keys():
-            body_queries[field].append(terms[i])
+            body_queries[field] = body_queries[field] + terms[i].split(' ')
         else:
-            body_queries[field] = [terms[i]]
+            body_queries[field] = terms[i].split(' ')
 
     terms = [
         {'terms': {key: value}} for key, value in body_queries.items()]


### PR DESCRIPTION
# Description
This PR fix #381 by splitting the terms of the queries by spaces before querying the database. This behaviour is due to ES way of querying texts (see match queries vs term query -> https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html#avoid-term-query-text-fields ).

This PR also now tests for the query builder to generate a correct set of terms for the queried field if the query included spaces (aka was a sentence)

## Type of change

- [x] :bug: Bug fix

# How Has This Been Tested?
Local runs
New tests
`make docker-test`
