### PR TITLE
Implement the sort by policy docs count

### DIFF
--- a/reach/airflow/tasks/fuzzy_match_refs.py
+++ b/reach/airflow/tasks/fuzzy_match_refs.py
@@ -113,6 +113,7 @@ class ElasticsearchFuzzyMatcher:
                 'match_doi': matched_reference.get('doc', {}).get('doi', None),
                 'match_issn': matched_reference.get('doc', {}).get('journalISSN', None),
                 'match_source': 'EPMC',
+                'associated_policies_count': 1,
 
                 # Policy information
                 'policies': [{
@@ -192,6 +193,10 @@ class FuzzyMatchRefsOperator(BaseOperator):
             if fuzzy_matched_reference:
                 ref_id = fuzzy_matched_reference['reference_id']
                 if ref_id in references.keys():
+
+                    references[ref_id]['policies'][
+                        'associated_policies_count'] += 1
+
                     references[ref_id]['policies'].append(
                         fuzzy_matched_reference['policies'][0]
                     )

--- a/reach/web/templates/results/citations.html
+++ b/reach/web/templates/results/citations.html
@@ -108,7 +108,7 @@
                                 <th width="10%" class="sort" data-sort="match_publication">Journal <span class="icn icn-sort"></span></th>
                                 <th width="20%" >Author(s)</span></th>
                                 <th width="10%" class="sort" data-sort="match_pub_year">Publication Year <span class="icn icn-sort"></span></th>
-                                <th width="10%" >Citations in policy&nbspdocs</th>
+                                <th width="10%" class="sort" data-sort="associated_policies_count">Citations in policy docs  <span class="icn icn-sort"></span></th>
                             </tr>
                         </thead>
                         <tbody id="citations-results-tbody">


### PR DESCRIPTION
# Description

A sort by number of associated policy documents is needed for usability testing. This PR adds this field to the citations and adds a sortable column to the results table for citation.

Fix #423 

## Type of change

- [x] :bug: Bug fix
- [x] :sparkles: New feature

# How Has This Been Tested?

Local runs
`make docker-test`

