### PR TITLE
Fix a wrong key inthe fuzzy match task

### DIFF
--- a/reach/airflow/tasks/fuzzy_match_refs.py
+++ b/reach/airflow/tasks/fuzzy_match_refs.py
@@ -194,7 +194,7 @@ class FuzzyMatchRefsOperator(BaseOperator):
                 ref_id = fuzzy_matched_reference['reference_id']
                 if ref_id in references.keys():
 
-                    references[ref_id]['policies'][
+                    references[ref_id][
                         'associated_policies_count'] += 1
 
                     references[ref_id]['policies'].append(


### PR DESCRIPTION
Fix a typo in the fuzzy matching task where it tried to increment the number of policy document in ['policies'] instead of the root key