### PR TITLE
Remove authors column header again

### DIFF
--- a/reach/web/templates/results/policy-docs.html
+++ b/reach/web/templates/results/policy-docs.html
@@ -105,7 +105,6 @@
                             <tr>
                                 <th class="sort" data-sort="title.keyword">Policy Document <span class="icn icn-sort"></th>
                                 <th class="sort" data-sort="organisation" data-order="asc" id="active-sort">Organisation <span class="icn icn-sort"></th>
-                                <th>Author(s)</th>
                                 <th class="sort" data-sort="year">Year of publication <span class="icn icn-sort"></th>
                             </tr>
                         </thead>


### PR DESCRIPTION
# Description

Remove the authors column headers again from the policy docs results page.