### PR TITLE
Fix fuzzymatcher task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ run-indexer-epmc: indexer-image
 		-e SENTRY_DSN="${SENTRY_DSN}" \
 		-e ES_HOST=${DOCKER_LOCALHOST} \
 		--network=host \
-		${ECR_ARN}/reach-indexer \
+		${ECR_ARN}/reach-es-indexer \
 		${EPMC_METADATA_KEY} \
 		${ORG} \
 		epmc \
@@ -242,11 +242,11 @@ run-fuzzymatcher: fuzzymatcher-image
 		-e SENTRY_DSN="${SENTRY_DSN}" \
 		-e ES_HOST=${DOCKER_LOCALHOST} \
 		--network=host \
-		${ECR_ARN}/reach-fuzzymatcher \
+		${ECR_ARN}/reach-fuzzy-matcher \
 		${EXTRACTER_PARSED_DST} \
 		${FUZZYMATCHER_DST} \
 		${ORG} \
-		fulltexts
+		epmc_metadata
 
 
 .PHONY: run-indexer-citations

--- a/pipeline/reach-fuzzy-matcher/fuzzymatcher_task.py
+++ b/pipeline/reach-fuzzy-matcher/fuzzymatcher_task.py
@@ -188,7 +188,7 @@ class FuzzyMatchRefsOperator(object):
                 ref_id = fuzzy_matched_reference['reference_id']
                 if ref_id in references.keys():
 
-                    references[ref_id]['policies'][
+                    references[ref_id][
                         'associated_policies_count'] += 1
 
                     references[ref_id]['policies'].append(
@@ -255,12 +255,12 @@ if __name__ == '__main__':
     )
     arg_parser.add_argument(
         '--score_threshold',
-        default=None,
+        default=50,
         help="The maximum number of items to index."
     )
     arg_parser.add_argument(
         '--should_match_threshold',
-        default=None,
+        default=80,
         help="The maximum number of items to index."
     )
 


### PR DESCRIPTION
# Description

Reach fuzzy-matcher task had a few issues:
 - No defaults for `should_match_threshold` and `score_threshold`, leading to some issue with the ES query
 - Fix a typo in the dict index we use to store `associated_policy_docs`

## Type of change

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?
Local runs
Runs on staging argo
`make docker-test`
