### PR TITLE
Rewrite Reach Frontend to account for new PSQL backend

### DIFF
--- a/web/web/src/js/citationsTable.js
+++ b/web/web/src/js/citationsTable.js
@@ -27,8 +27,14 @@ function getCitationsTableContent(data) {
         authors += Object.values(author).join('. ');
       }
       let match_title = item.title ? item.title.toTitleCase() : "Title unavailable";
-      rows += `<tr class="accordion-row" id="accordion-row-${item.uuid}">`;
-      rows += `<td class="accordion-arrow"><i class="icon icon-arrow-down mr-1"></i></td>`
+
+      if (item.policies) {
+        rows += `<tr class="accordion-row" id="accordion-row-${item.uuid}">`;
+        rows += `<td class="accordion-arrow"><i class="icon icon-arrow-down mr-1"></i></td>`
+      } else {
+        rows += `<tr class="empty-accordion-row" id="accordion-row-${item.uuid}">`;
+        rows += `<td class="accordion-arrow"</td>`
+      }
       rows += `<td title="${match_title}"><div>${match_title}</div></td>`;
       rows += `<td>${item.journal_title}</td>`;
       rows += `<td class="authors-cell" title="${authors}"><div>
@@ -37,39 +43,39 @@ function getCitationsTableContent(data) {
       rows += `<td>${item.pub_year}</td>`;
 
       if (item.policies) {
-      rows += `<td>${item.policies.length}</td>`;
-      rows += `</tr>`;
+        rows += `<td>${item.policies.length}</td>`;
+        rows += `</tr>`;
 
-      rows += `<tr class="accordion-body fadeout" id="accordion-body-${item.uuid}">
-                  <td></td>
-                  <td colspan=4 class="accordion-subtable-container"><div>
-                  <table class="table accordion-subtable">
-                      <colgroup>
-                          <col class="colgroup-accordion-col">
-                          <col class="colgroup-subtable-col">
-                          <col class="colgroup-medium-col">
-                          <col>
-                      </colgroup>
-                      <tr>
-                          <th colspan="2">Cited in the following Policy Documents</th>
-                          <th>Policy Organisation</th>
-                          <th>Publication Year</th>
-                      </tr>
-      `;
-      for (let policy of item.policies) {
-          let policy_title = policy.title ? policy.title.toTitleCase() : "Title unavailable";
-          rows += `<tr>`;
-          rows += `<td><span class="icn icn-new-page"></span></td>`
-          rows += `<td title="${policy_title}"><a
-             href="${policy.source_url}"
-             target="_blank"
-             rel="noreferrer noopener"
-          >${(policy_title.length > TITLE_LENGTH) ? (policy_title.slice(0, TITLE_LENGTH) + "...") : policy_title}</a></td>`;
-          rows += `<td>${toDisplayOrg(policy.source_org)}</td>`;
-          rows += `<td>${policy.year}</td>`;
-      }
-      rows += `</table></div></td>`
-      rows += `</tr>`;
+        rows += `<tr class="accordion-body fadeout" id="accordion-body-${item.uuid}">
+                    <td></td>
+                    <td colspan=4 class="accordion-subtable-container"><div>
+                    <table class="table accordion-subtable">
+                        <colgroup>
+                            <col class="colgroup-accordion-col">
+                            <col class="colgroup-subtable-col">
+                            <col class="colgroup-medium-col">
+                            <col>
+                        </colgroup>
+                        <tr>
+                            <th colspan="2">Cited in the following Policy Documents</th>
+                            <th>Policy Organisation</th>
+                            <th>Publication Year</th>
+                        </tr>
+        `;
+        for (let policy of item.policies) {
+            let policy_title = policy.title ? policy.title.toTitleCase() : "Title unavailable";
+            rows += `<tr>`;
+            rows += `<td><span class="icn icn-new-page"></span></td>`
+            rows += `<td title="${policy_title}"><a
+               href="${policy.source_url}"
+               target="_blank"
+               rel="noreferrer noopener"
+            >${(policy_title.length > TITLE_LENGTH) ? (policy_title.slice(0, TITLE_LENGTH) + "...") : policy_title}</a></td>`;
+            rows += `<td>${toDisplayOrg(policy.source_org)}</td>`;
+            rows += `<td>${policy.year}</td>`;
+        }
+        rows += `</table></div></td>`
+        rows += `</tr>`;
 
       }
       else {

--- a/web/web/src/js/citationsTable.js
+++ b/web/web/src/js/citationsTable.js
@@ -6,6 +6,8 @@ import {
     toDisplayOrg,
 } from './resultsCommon.js';
 
+import getNoResultsTemplate from './templates/no_results.js';
+
 const TITLE_LENGTH = 140;
 
 const searchFields = [
@@ -19,51 +21,65 @@ const searchFields = [
 
 function getCitationsTableContent(data) {
     let rows = ``;
-    data.data.forEach((item) => {
-        let authors = item._source.doc.match_authors ? item._source.doc.match_authors : "Authors unavailable";
-        let match_title = item._source.doc.match_title ? item._source.doc.match_title.toTitleCase() : "Title unavailable";
-        rows += `<tr class="accordion-row" id="accordion-row-${item._source.doc.reference_id}">`;
-        rows += `<td class="accordion-arrow"><i class="icon icon-arrow-down mr-1"></i></td>`
-        rows += `<td title="${match_title}"><div>${match_title}</div></td>`;
-        rows += `<td>${item._source.doc.match_publication}</td>`;
-        rows += `<td class="authors-cell" title="${authors}"><div>
-            ${authors}</div>
-        </td>`;
-        rows += `<td>${item._source.doc.match_pub_year}</td>`;
-        rows += `<td>${item._source.doc.policies.length}</td>`;
-        rows += `</tr>`;
+    for (let item of data) {
+      let authors = '';
+      for (let author of  item.authors) {
+        authors += Object.values(author).join('. ');
+      }
+      let match_title = item.title ? item.title.toTitleCase() : "Title unavailable";
+      rows += `<tr class="accordion-row" id="accordion-row-${item.uuid}">`;
+      rows += `<td class="accordion-arrow"><i class="icon icon-arrow-down mr-1"></i></td>`
+      rows += `<td title="${match_title}"><div>${match_title}</div></td>`;
+      rows += `<td>${item.journal_title}</td>`;
+      rows += `<td class="authors-cell" title="${authors}"><div>
+          ${authors}</div>
+      </td>`;
+      rows += `<td>${item.pub_year}</td>`;
 
-        rows += `<tr class="accordion-body fadeout" id="accordion-body-${item._source.doc.reference_id}">
+      if (item.policies) {
+      rows += `<td>${item.policies.length}</td>`;
+      rows += `</tr>`;
+
+      rows += `<tr class="accordion-body fadeout" id="accordion-body-${item.uuid}">
+                  <td></td>
+                  <td colspan=4 class="accordion-subtable-container"><div>
+                  <table class="table accordion-subtable">
+                      <colgroup>
+                          <col class="colgroup-accordion-col">
+                          <col class="colgroup-subtable-col">
+                          <col class="colgroup-medium-col">
+                          <col>
+                      </colgroup>
+                      <tr>
+                          <th colspan="2">Cited in the following Policy Documents</th>
+                          <th>Policy Organisation</th>
+                          <th>Publication Year</th>
+                      </tr>
+      `;
+      for (let policy of item.policies) {
+          let policy_title = policy.title ? policy.title.toTitleCase() : "Title unavailable";
+          rows += `<tr>`;
+          rows += `<td><span class="icn icn-new-page"></span></td>`
+          rows += `<td title="${policy_title}"><a
+             href="${policy.source_url}"
+             target="_blank"
+             rel="noreferrer noopener"
+          >${(policy_title.length > TITLE_LENGTH) ? (policy_title.slice(0, TITLE_LENGTH) + "...") : policy_title}</a></td>`;
+          rows += `<td>${toDisplayOrg(policy.source_org)}</td>`;
+          rows += `<td>${policy.year}</td>`;
+      }
+      rows += `</table></div></td>`
+      rows += `</tr>`;
+
+      }
+      else {
+        rows += `<td>0</td>`;
+        rows += `<tr class="accordion-body fadeout" id="accordion-body-${item.uuid}">
                     <td></td>
-                    <td colspan=4 class="accordion-subtable-container"><div>
-                    <table class="table accordion-subtable">
-                        <colgroup>
-                            <col class="colgroup-accordion-col">
-                            <col class="colgroup-subtable-col">
-                            <col class="colgroup-medium-col">
-                            <col>
-                        </colgroup>
-                        <tr>
-                            <th colspan="2">Cited in the following Policy Documents</th>
-                            <th>Policy Organisation</th>
-                            <th>Publication Year</th>
-                        </tr>
-        `;
-        for (let policy of item._source.doc.policies) {
-            let policy_title = policy.title ? policy.title.toTitleCase() : "Title unavailable";
-            rows += `<tr>`;
-            rows += `<td><span class="icn icn-new-page"></span></td>`
-            rows += `<td title="${policy_title}"><a
-               href="${policy.source_url}"
-               target="_blank"
-               rel="noreferrer noopener"
-            >${(policy_title.length > TITLE_LENGTH) ? (policy_title.slice(0, TITLE_LENGTH) + "...") : policy_title}</a></td>`;
-            rows += `<td>${toDisplayOrg(policy.organisation)}</td>`;
-            rows += `<td>${item._source.doc.match_pub_year}</td>`;
-        }
-        rows += `</table></div></td>`
-        rows += `</tr>`;
-    });
+                    <td colspan=4 class="accordion-subtable-container"><div></div></td>
+                 </tr>`;
+      }
+    }
     return rows;
 }
 
@@ -71,18 +87,24 @@ function refreshCitations(data, currentState) {
     // Get the parameters from the policy docs search page and use them
     // to query Elasticsearch
 
+    const resultBox = document.getElementById('policy-docs-results');
     const table = document.getElementById('citations-results-tbody');
     // const loadingRow = document.getElementById('loading-row');
     const pages = document.getElementsByClassName('page-item');
     const accordions = document.getElementsByClassName('accordion-row');
 
-    table.innerHTML = getCitationsTableContent(data);
+    if (parseInt(data.count) <= 0) {
+      resultBox.innerHTML = getNoResultsTemplate(data.terms, 'citations');
+      return null;
+    }
+
+    table.innerHTML = getCitationsTableContent(data.data);
 
     for (let htmlElement of document.getElementsByClassName('pagination-box'))
     {
             htmlElement.innerHTML = getPagination(
             currentState.page,
-            data,
+            parseInt(data.count),
         );
     }
 
@@ -90,7 +112,7 @@ function refreshCitations(data, currentState) {
     {
             htmlElement.innerHTML = getCounter(
             currentState.page,
-            data,
+            parseInt(data.count),
         );
     }
 
@@ -118,6 +140,45 @@ function refreshCitations(data, currentState) {
                 // newPage is an integer
                 currentState.page = parseInt(newPage.getAttribute('data-page'));
             }
+            getData('citations', currentState, refreshCitations);
+        });
+    };
+
+    const headers = document.getElementsByClassName('sort');
+
+    for (let item of headers) {
+        item.addEventListener('click', (e) => {
+            let newSort = e.currentTarget.getAttribute('data-sort');
+            let currentSort = document.getElementById('active-sort');
+            let currentState = getCurrentState();
+
+            currentState.fields = searchFields;
+            if (newSort === currentState.sort) {
+                if (currentSort.getAttribute('data-order') === 'asc') {
+                    currentState.order = 'desc';
+                    currentSort.setAttribute('data-order', 'desc');
+
+                    currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted icn-sorted-asc');
+                }
+                else {
+                    currentState.order = 'asc';
+                    currentSort.setAttribute('data-order', 'asc');
+
+                    currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
+                }
+            }
+
+            else {
+                e.currentTarget.setAttribute('data-order', 'asc');
+
+                currentSort.setAttribute('id', null);
+                e.currentTarget.setAttribute('id', 'active-sort');
+
+                currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sort');
+                e.currentTarget.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
+
+            }
+            currentState.sort = newSort;
             getData('citations', currentState, refreshCitations);
         });
     };
@@ -150,51 +211,12 @@ function refreshCitations(data, currentState) {
 
 
 const citationsTable = () => {
-    const citation_table = document.getElementById('citations-result-table');
+    const resultBox = document.getElementById('citations-results');
 
-    if (citation_table) {
-        const headers = document.getElementsByClassName('sort');
-
-        for (let item of headers) {
-            item.addEventListener('click', (e) => {
-                let newSort = e.currentTarget.getAttribute('data-sort');
-                let currentSort = document.getElementById('active-sort');
-                let currentState = getCurrentState();
-
-                currentState.fields = searchFields;
-                if (newSort === currentState.sort) {
-                    if (currentSort.getAttribute('data-order') === 'asc') {
-                        currentState.order = 'desc';
-                        currentSort.setAttribute('data-order', 'desc');
-
-                        currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted icn-sorted-asc');
-                    }
-                    else {
-                        currentState.order = 'asc';
-                        currentSort.setAttribute('data-order', 'asc');
-
-                        currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
-                    }
-                }
-
-                else {
-                    e.currentTarget.setAttribute('data-order', 'asc');
-
-                    currentSort.setAttribute('id', null);
-                    e.currentTarget.setAttribute('id', 'active-sort');
-
-                    currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sort');
-                    e.currentTarget.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
-
-                }
-                currentState.sort = newSort;
-                getData('citations', currentState, refreshCitations);
-            });
-        };
-
-        let body = getCurrentState();
-        body.fields = searchFields;
-        getData('citations', body, refreshCitations);
+    if (resultBox) {
+      let body = getCurrentState(resultBox.getAttribute('data-search'));
+      body.fields = searchFields;
+      getData('citations', body, refreshCitations);
     }
 }
 

--- a/web/web/src/js/policyTable.js
+++ b/web/web/src/js/policyTable.js
@@ -6,6 +6,8 @@ import {
     toDisplayOrg,
 } from './resultsCommon.js';
 
+import getNoResultsTemplate from './templates/no_results.js';
+
 const searchFields = [
     'title',
     'source_org',
@@ -19,10 +21,10 @@ const getPolicyTableContent = (data) => {
 
     let rows = ``;
     for(let item of data) {
-        if (!item['source_doc_url']) {
+        if (!item.source_doc_url) {
             continue;
         }
-        let title = (item['title'])? item['title'].toTitleCase():"Title unavailable";
+        let title = (item.title)? item.title.toTitleCase():"Title unavailable";
         rows += `<tr>`;
         rows += `<td class="new-page-icon-cell"><a
             href="${item.source_doc_url}"
@@ -30,12 +32,12 @@ const getPolicyTableContent = (data) => {
             rel="noreferrer noopener"
         ><span class="icn icn-new-page"></span></td>`;
         rows += `<td title="${title}"><a
-            href="${item['source_doc_url']}"
+            href="${item.source_doc_url}"
             target="_blank"
             rel="noreferrer noopener"
         >${(title.length > TITLE_LENGTH) ? (title.slice(0, TITLE_LENGTH) + "...") : title}</a></td>`;
-        rows += `<td>${toDisplayOrg(item['source_org'])}</td>`;
-        rows += `<td>${item['year']?item['year']:"Unknown"}</td>`;
+        rows += `<td>${toDisplayOrg(item.source_org)}</td>`;
+        rows += `<td>${item.year ? item.year : "Unknown"}</td>`;
         rows += `</tr>`;
 
     }
@@ -46,27 +48,32 @@ const getPolicyTableContent = (data) => {
 const refreshPolicy = (data, currentState) => {
     // Get the parameters from the policy docs search page and use them
     // to query Elasticsearch
-
+    const resultBox = document.getElementById('policy-docs-results');
     const table = document.getElementById('policy-docs-results-tbody');
     // const loadingRow = document.getElementById('loading-row');
     const pages = document.getElementsByClassName('page-item');
 
-    table.innerHTML = getPolicyTableContent(data['data']);
+    if (parseInt(data.count) <= 0) {
+      resultBox.innerHTML = getNoResultsTemplate(data.terms, 'policies');
+      return null;
+    }
+
+    table.innerHTML = getPolicyTableContent(data.data);
 
     for (let htmlElement of document.getElementsByClassName('pagination-box'))
     {
-            htmlElement.innerHTML = getPagination(
-            currentState.page,
-            data,
-        );
+      htmlElement.innerHTML = getPagination(
+        currentState.page,
+        parseInt(data.count),
+      );
     }
 
     for (let htmlElement of document.getElementsByClassName('page-counter'))
     {
-            htmlElement.innerHTML = getCounter(
-            currentState.page,
-            data,
-        );
+      htmlElement.innerHTML = getCounter(
+          currentState.page,
+          parseInt(data.count),
+      );
     }
 
     for (let item of pages) {
@@ -95,53 +102,52 @@ const refreshPolicy = (data, currentState) => {
             getData('policy-docs', currentState, refreshPolicy);
         });
     };
+
+    const headers = document.getElementsByClassName('sort');
+
+    for (let item of headers) {
+        item.addEventListener('click', (e) => {
+            let newSort = e.currentTarget.getAttribute('data-sort');
+            let currentSort = document.getElementById('active-sort');
+            let currentState = getCurrentState();
+
+            currentState.fields = searchFields;
+            if (newSort == currentSort.getAttribute('data-sort')) {
+                if (currentSort.getAttribute('data-order') === 'asc') {
+                    currentState.order = 'desc';
+                    currentSort.setAttribute('data-order', 'desc');
+
+                    currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted  icn-sorted-asc');
+                }
+                else {
+                    currentState.order = 'asc';
+                    currentSort.setAttribute('data-order', 'asc');
+
+                    currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
+                }
+            }
+
+            else {
+                e.currentTarget.setAttribute('data-order', 'asc');
+
+                currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sort');
+                e.currentTarget.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
+            }
+
+            currentSort.setAttribute('id', null);
+            e.currentTarget.setAttribute('id', 'active-sort');
+            currentState.sort = newSort;
+            getData('policy-docs', currentState, refreshPolicy);
+        });
+    };
 }
 
 const policyTable = () => {
-    const policy_table = document.getElementById('policy-docs-result-table');
+    const resultBox = document.getElementById('policy-docs-results');
 
-    if (policy_table) {
-        const headers = document.getElementsByClassName('sort');
-
-        for (let item of headers) {
-            item.addEventListener('click', (e) => {
-                let newSort = e.currentTarget.getAttribute('data-sort');
-                let currentSort = document.getElementById('active-sort');
-                let currentState = getCurrentState();
-
-                currentState.fields = searchFields;
-                if (newSort == currentSort.getAttribute('data-sort')) {
-                    if (currentSort.getAttribute('data-order') === 'asc') {
-                        currentState.order = 'desc';
-                        currentSort.setAttribute('data-order', 'desc');
-
-                        currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted  icn-sorted-asc');
-                    }
-                    else {
-                        currentState.order = 'asc';
-                        currentSort.setAttribute('data-order', 'asc');
-
-                        currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
-                    }
-                }
-
-                else {
-                    e.currentTarget.setAttribute('data-order', 'asc');
-
-                    currentSort.querySelector('.icn').setAttribute('class', 'icn icn-sort');
-                    e.currentTarget.querySelector('.icn').setAttribute('class', 'icn icn-sorted');
-                }
-
-                currentSort.setAttribute('id', null);
-                e.currentTarget.setAttribute('id', 'active-sort');
-                currentState.sort = newSort;
-                getData('policy-docs', currentState, refreshPolicy);
-            });
-        };
-
-        let body = getCurrentState();
+    if (resultBox) {
+        let body = getCurrentState(resultBox.getAttribute('data-search'));
         body.fields = searchFields;
-        console.log("HERE");
         getData('policy-docs', body, refreshPolicy);
     }
 }

--- a/web/web/src/js/resultsCommon.js
+++ b/web/web/src/js/resultsCommon.js
@@ -14,7 +14,7 @@ export function toDisplayOrg(org) {
     return ORGS[org];
 }
 
-export function getPagination(currentPage, data) {
+export function getPagination(currentPage, itemCount) {
     // Create the pagination list relative to the current state
 
     let pages = ``;
@@ -25,7 +25,7 @@ export function getPagination(currentPage, data) {
         pages += `<li class="btn disabled-page-item" id="page-previous"><i class="icn icn-chevron-left"></i> Prev</li>`;
     }
 
-    const maxPages = parseInt(Math.ceil(data['hits'] / SIZE));
+    const maxPages = parseInt(Math.ceil(itemCount / SIZE)) - 1;
 
     if (currentPage > 2) {
         pages += `<li class="page-item" data-page="0">1</li>`;
@@ -65,14 +65,14 @@ export function getPagination(currentPage, data) {
 
 }
 
-export function getCounter(currentPage, data) {
+export function getCounter(currentPage, itemCount) {
     // Create the results counter (displyed `Docs XX to YY of ZZ`)
 
     currentPage = parseInt(currentPage);
     let currentMin = SIZE * currentPage + 1;
-    let currentMax = Math.min(currentMin + SIZE, data['hits']);
+    let currentMax = Math.min(currentMin + SIZE, itemCount);
 
-    return `<span>Showing ${currentMin} - ${currentMax} of ${data['hits']} results</span>`;
+    return `<span>Showing ${currentMin} - ${currentMax} of ${itemCount} results</span>`;
 }
 
 export function getData(type, body, callback) {
@@ -105,7 +105,11 @@ export function getData(type, body, callback) {
     xhr.send();
 
     const load = setTimeout(() => {
-      document.getElementById('policy-docs-result-table').classList.add("load");
+      let table = document.getElementById('citations-result-table');
+      if (!table) {
+        table = table = document.getElementById('policy-docs-result-table');
+      }
+      table.classList.add("load");
       document.getElementById('loading-row').classList.remove("d-none");
     }, 2000);
 
@@ -136,21 +140,21 @@ export function getData(type, body, callback) {
     };
 }
 
-export function getCurrentState() {
+export function getCurrentState(term=null) {
     /* Get the current values for the search term, order, sorting and page and
     return them as a dictionary, used for both refreshing the table and
     query new data through the API. */
 
     const currentPage = document.getElementById('active-page');
     const currentSort = document.getElementById('active-sort');
-    const searchTerm = document.getElementById('search-term');
+    const searchTerm = term ? term : document.getElementById('search-term').value;
 
     let body = {
-        term: searchTerm.value,
+        term: searchTerm,
         size: SIZE,
         page: (currentPage) ? parseInt(currentPage.getAttribute('data-page')) : 0,
-        sort: currentSort.getAttribute('data-sort'),
-        order: currentSort.getAttribute('data-order'),
+        sort: currentSort ? currentSort.getAttribute('data-sort') : null,
+        order: currentSort ? currentSort.getAttribute('data-order') : 'desc',
     };
     return body;
 }

--- a/web/web/src/js/templates/no_results.js
+++ b/web/web/src/js/templates/no_results.js
@@ -1,0 +1,77 @@
+const getNoResultsTemplate = (term, source) => {
+
+  let noResultsTitle = ``;
+  let formLabel = ``;
+  let formAction = ``;
+  let formSubmit = ``;
+
+  if (source == 'policies') {
+    noResultsTitle = `Your search for "${term}" in policy&nbspdocuments did not return any results`;
+    formLabel = `Search by policy document title, policy organisation or topic`;
+    formAction = `/search/policy-docs`;
+    formSubmit = `Browse policy documents`;
+  } else {
+    noResultsTitle = `Your search for "${term}" in citations did not return any results`;
+    formLabel = `Search by publication title, journal or year of publication`;
+    formAction = `/search/citations`;
+    formSubmit = `Discover citations`;
+  }
+
+  const template = `
+  <div class="container">
+    <hr class="hs">
+    <div class="columns">
+      <div class="column col-8 col-md-12">
+        <h1>${noResultsTitle}</h1>
+      </div>
+    </div>
+    <div class="columns">
+      <div class="column col-6 col-md-12"></div>
+      <div class="column col-6 hide-md"></div>
+    </div>
+    <div class="columns">
+      <hr class="hs">
+      <div class="column col-12">
+        <p class="form-label">${formLabel}</p>
+      </div>
+      <div class="column col-6 col-md-12">
+        <form action="${formAction}">
+          <div class="input-group">
+            <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term" value="${term}">
+            <button type="submit" class="btn btn-primary input-group-btn input-btn-xl">${formSubmit}<span class="icn icn-search"></span></button>
+          </div>
+        </form>
+      </div>
+      <div class="column col-6 hide-md"></div>
+    </div>
+    <hr class="fs">
+    <div class="columns">
+      <div class="column col-6 col-md-12">
+        <h3 class="tips-title">Search tips</h3>
+        <ul class="tips-list">
+          <li>Check your spelling</li>
+          <li>Broaden your search by using fewer words or more general terms</li>
+          <li>Try searching by topic, area or work or insitute</li>
+        </ul>
+      </div>
+      <div class="column col-6 hide-md"></div>
+    </div>
+    <hr class="fs">
+    <hr class="fs">
+      <div class="columns">
+        <div class="column col-6 col-md-12">
+          <div class="feedback-box">
+            <p class="bold">Can't find what you're looking for?</p>
+            <p>If something doesn’t look quite right, please get in touch with the team at <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk.</a></p>
+          </div>
+        </div>
+      <div class="column col-6 hide-md"></div>
+    </div>
+  </div>
+  <hr class="fs">
+  `;
+
+  return template;
+};
+
+export default getNoResultsTemplate;

--- a/web/web/templates/contact.html
+++ b/web/web/templates/contact.html
@@ -4,10 +4,10 @@
 
 <header class="navbar">
   <section class="navbar-section">
-        <a href="/" class="navbar-brand"><h2>Reach</h2></a>
+    <a href="/" class="navbar-brand"><img src="/static/images/reach_alpha_branding.svg" alt=""></a>
   </section>
   <section class="navbar-section hide-md" id="navbar-links">
-    <a href="/about" class="a-light active">About Reach</a>
+    <a href="/about" class="a-light">About Reach</a>
     <a href="/how-it-works" class="a-light">How Reach works</a>
     <a href="/search/citations" class="a-light">Discover citations</a>
     <a href="/search/policy-docs" class="a-light">Browse policy documents</a>

--- a/web/web/templates/results/citations.html
+++ b/web/web/templates/results/citations.html
@@ -301,16 +301,16 @@
       <thead>
         <tr>
           <th></th>
-            <th class="sort" data-sort="match_title.keyword" data-order="asc" id="active-sort">
+            <th class="sort" data-sort="title" data-order="asc" id="active-sort">
               Research publication
               <span class="icn icn-sorted"></span>
             </th>
-            <th class="sort" data-sort="match_publication">
+            <th class="sort" data-sort="journal_title">
               Jounal
               <span class="icn icn-sort"></span>
             </th>
             <th>Author(s)</th>
-            <th class="sort" data-sort="match_pub_year">
+            <th class="sort" data-sort="pub_year">
               <div class="table-header">
                 <div class="table-header-text">
                   Publication of Year

--- a/web/web/templates/results/citations.html
+++ b/web/web/templates/results/citations.html
@@ -35,25 +35,19 @@
   </div>
 </section>
 
-<section id="citations-results" class="results-box">
+<section id="citations-results" class="results-box" data-search="{{ term }}">
+
+  {#- This will is only used as load indication, and is overwritten in JS #}
   <div class="container">
     <hr class="hs">
     <div class="columns">
       <div class="column col-8 col-md-12">
-      {% if status %}
         <h1>Results for "{{ term }}" in citations</h1>
-      {% else %}
-        <h1>Your search for "{{ term }}" in citations did not return any results</h1>
-      {% endif %}
       </div>
     </div>
     <div class="columns">
       <div class="column col-6 col-md-12">
-      {% if status %}
         <p>Searching for "<span class="text-bold">{{ term }}</span>" in over 1.1 million research publications that have been cited in policy documents.</p>
-      {% else %}
-        {#- Placeholder for the search suggestion feature #}
-      {% endif %}
       </div>
       <div class="column col-6 hide-md"></div>
     </div>
@@ -65,52 +59,19 @@
       <div class="column col-6 col-md-12">
         <form action="/search/citations">
           <div class="input-group">
-            <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term" value="{{ terms }}">
+            <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term" value="{{ term }}">
             <button type="submit" class="btn btn-primary input-group-btn input-btn-xl">Discover citations <span class="icn icn-search"></span></button>
           </div>
         </form>
       </div>
-    {% if status %}
       <div class="column col-6 col-md-12 text-right">
         <a class="btn btn-primary btn-xl" href="/search/citations/csv?terms={{ term }}">Download results as .csv <span class="icn icn-download"></span></a>
         <!-- To be uncommented with further UI updates
         <a class="btn btn-primary btn-xl btn-download" href="/search/citations/json?terms={{ term }}" >Download results as .json <span class="icn icn-download"></span></a>
         -->
       </div>
-    {% else %}
-      <div class="column col-6 hide-md"></div>
-    {% endif %}
     </div>
-
-{#- No results page body #}
-    {% if not status %}
-    <hr class="fs">
-    <div class="columns">
-      <div class="column col-6 col-md-12">
-        <h3 class="tips-title">Search tips</h3>
-        <ul class="tips-list">
-          <li>Check your spelling</li>
-          <li>Broaden your search by using fewer words or more general terms</li>
-          <li>Try searching by topic, area or work or insitute</li>
-        </ul>
-      </div>
-      <div class="column col-6 hide-md"></div>
-    </div>
-    <hr class="fs">
-    <hr class="fs">
-    <div class="columns">
-      <div class="column col-6 col-md-12">
-        <div class="feedback-box">
-          <p class="bold">Can't find what you're looking for?</p>
-          <p>If something doesn’t look quite right, please get in touch with the team at <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk.</a></p>
-        </div>
-      </div>
-      <div class="column col-6 hide-md"></div>
-    </div>
-  </div> {#- Closing .container #}
-  <hr class="fs">
-    {% else %}
-  </div> {#- Alternative closing for .container #}
+  </div>
   <div class="results">
     <div class="container">
       <hr class="hs">
@@ -225,6 +186,199 @@
     </div>
   </div>
   <hr class="fs">
-    {% endif %}
 </section>
+{% endblock %}
+
+
+{% block hide %}
+<div class="container">
+  <hr class="hs">
+  <div class="columns">
+    <div class="column col-8 col-md-12">
+    {% if status %}
+      <h1>Results for "{{ term }}" in citations</h1>
+    {% else %}
+      <h1>Your search for "{{ term }}" in citations did not return any results</h1>
+    {% endif %}
+    </div>
+  </div>
+  <div class="columns">
+    <div class="column col-6 col-md-12">
+    {% if status %}
+      <p>Searching for "<span class="text-bold">{{ term }}</span>" in over 1.1 million research publications that have been cited in policy documents.</p>
+    {% else %}
+      {#- Placeholder for the search suggestion feature #}
+    {% endif %}
+    </div>
+    <div class="column col-6 hide-md"></div>
+  </div>
+  <div class="columns">
+    <hr class="hs">
+    <div class="column col-12">
+      <p class="form-label">Search by publication title, journal or year of publication</p>
+    </div>
+    <div class="column col-6 col-md-12">
+      <form action="/search/citations">
+        <div class="input-group">
+          <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term" value="{{ terms }}">
+          <button type="submit" class="btn btn-primary input-group-btn input-btn-xl">Discover citations <span class="icn icn-search"></span></button>
+        </div>
+      </form>
+    </div>
+  {% if status %}
+    <div class="column col-6 col-md-12 text-right">
+      <a class="btn btn-primary btn-xl" href="/search/citations/csv?terms={{ term }}">Download results as .csv <span class="icn icn-download"></span></a>
+      <!-- To be uncommented with further UI updates
+      <a class="btn btn-primary btn-xl btn-download" href="/search/citations/json?terms={{ term }}" >Download results as .json <span class="icn icn-download"></span></a>
+      -->
+    </div>
+  {% else %}
+    <div class="column col-6 hide-md"></div>
+  {% endif %}
+  </div>
+
+{#- No results page body #}
+  {% if not status %}
+  <hr class="fs">
+  <div class="columns">
+    <div class="column col-6 col-md-12">
+      <h3 class="tips-title">Search tips</h3>
+      <ul class="tips-list">
+        <li>Check your spelling</li>
+        <li>Broaden your search by using fewer words or more general terms</li>
+        <li>Try searching by topic, area or work or insitute</li>
+      </ul>
+    </div>
+    <div class="column col-6 hide-md"></div>
+  </div>
+  <hr class="fs">
+  <hr class="fs">
+  <div class="columns">
+    <div class="column col-6 col-md-12">
+      <div class="feedback-box">
+        <p class="bold">Can't find what you're looking for?</p>
+        <p>If something doesn’t look quite right, please get in touch with the team at <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk.</a></p>
+      </div>
+    </div>
+    <div class="column col-6 hide-md"></div>
+  </div>
+</div> {#- Closing .container #}
+<hr class="fs">
+  {% else %}
+</div> {#- Alternative closing for .container #}
+<div class="results">
+  <div class="container">
+    <hr class="hs">
+    <div class="columns">
+      <div class="column col-12 learn-link">
+        <span class="icn icn-info"></span><a href="/how-it-works">Learn about these results</a>
+      </div>
+    </div>
+    <hr class="hs">
+    <div class="results-pages">
+      <div class="columns">
+        <div class="column col-6 col-md-12">
+          <div class="page-counter">
+            {#- Updated dynamically in JS #}
+          </div>
+        </div>
+        <div class="column col-6 col-md-12">
+          <div class="pagination-box float-right" id="pagination-box">
+            {#- Updated dynamically in JS #}
+          </div>
+        </div>
+      </div>
+    </div>
+    <table class="table table-light table-hover load"  id="citations-result-table" nowrap>
+      <colgroup>
+        <col class="colgroup-accordion-col">
+        <col class="colgroup-large-col">
+        <col class="colgroup-medium-col">
+        <col class="colgroup-medium-col">
+        <col class="colgroup-small-col">
+        <col class="colgroup-small-col">
+      </colgroup>
+      <thead>
+        <tr>
+          <th></th>
+            <th class="sort" data-sort="match_title.keyword" data-order="asc" id="active-sort">
+              Research publication
+              <span class="icn icn-sorted"></span>
+            </th>
+            <th class="sort" data-sort="match_publication">
+              Jounal
+              <span class="icn icn-sort"></span>
+            </th>
+            <th>Author(s)</th>
+            <th class="sort" data-sort="match_pub_year">
+              <div class="table-header">
+                <div class="table-header-text">
+                  Publication of Year
+                </div>
+                <div class="table-header-icon">
+                  <span class="icn icn-sort"></span>
+                </div>
+              </div>
+            </th>
+            <th class="sort" data-sort="associated_policies_count">
+              <div class="table-header">
+                <div class="table-header-text">
+                  Citations in policy docs
+                </div>
+                <div class="table-header-icon">
+                  <span class="icn icn-sort"></span>
+                </div>
+              </div>
+            </th>
+          </tr>
+          <tr class="progress-row d-none" id="loading-row">
+            <th colspan=7>
+              <progress class="progress" max="100"></progress>
+            </th>
+          </tr>
+        </thead>
+        <tbody id="citations-results-tbody">
+        {% for i in range(0, 10) %}
+          <tr class="load">
+            <td colspan=7></td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      <div class="results-pages">
+        <div class="columns">
+          <div class="column col-6 col-md-12">
+            <div class="page-counter">
+              {#- Updated dynamically in JS #}
+            </div>
+          </div>
+          <div class="column col-6 col-md-12">
+            <div class="pagination-box float-right" id="pagination-box">
+              {#- Updated dynamically in JS #}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container">
+  <hr class="fs">
+  <div class="columns">
+    <div class="column col-6 col-md-12">
+      <div class="feedback-box">
+        <p class="bold">About these results</p>
+        <p>To learn more about how reach works and how it has generated these results, go to the <a href="/how-it-works">How Reach works</a> page</p>
+      </div>
+    </div>
+    <div class="column col-6 col-md-12">
+      <div class="feedback-box">
+        <p class="bold">Can't find what you're looking for?</p>
+        <p>We are working to continually improve Reach, if it is not working as you expect, there is an error or you have a suggestion, please <a href="mailto:engineering.datalabs@wellcome.ac.uk">send us your feedback</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+<hr class="fs">
+  {% endif %}
 {% endblock %}

--- a/web/web/templates/results/policy-docs.html
+++ b/web/web/templates/results/policy-docs.html
@@ -35,7 +35,143 @@
   </div>
 </section>
 
-<section id="policy-docs-results" class="results-box">
+<section id="policy-docs-results" class="results-box" data-search="{{ term }}">
+
+  {#- This will is only used as load indication, and is overwritten in JS #}
+  <div class="container">
+    <hr class="hs">
+    <div class="columns">
+      <div class="column col-8 col-md-12">
+        <h1>Results for "{{ term }}" in policy documents</h1>
+      </div>
+    </div>
+    <div class="columns">
+      <div class="column col-6 col-md-12">
+        <p>Searching for “{{ term }}” in PDFs from the websites of UNICEF, Médecins Sans Frontières, National Insititute for Clinical Excellence, the World Health Organisation, UK Government and UK Parliament.</p>
+      </div>
+      <div class="column col-6 hide-md"></div>
+    </div>
+    <div class="columns">
+      <hr class="hs">
+      <div class="column col-12">
+        <p class="form-label">Search by policy document title, policy organisation or topic</p>
+      </div>
+      <div class="column col-6 col-md-12">
+        <form action="/search/policy-docs">
+          <div class="input-group">
+            <input type="text" class="form-input input-xl" placeholder="Search" name="terms" id="search-term" value="{{ term }}">
+            <button type="submit" class="btn btn-primary input-group-btn input-btn-xl">Browse policy documents <span class="icn icn-search"></span></button>
+          </div>
+        </form>
+      </div>
+      <div class="column col-6 col-md-12 text-right">
+        <a class="btn btn-primary btn-xl btn-download" href="/search/policy-docs/csv?terms={{ term }}" >Download results as .csv <span class="icn icn-download"></span></a>
+        <!-- To be uncommented with further UI updates
+        <a class="btn btn-primary btn-xl btn-download" href="/search/policy-docs/json?terms={{ term }}" >Download results as .json <span class="icn icn-download"></span></a>
+        -->
+      </div>
+    </div>
+  </div> {#- Alternative closing for .container #}
+  <div class="results">
+    <div class="container">
+      <hr class="hs">
+      <div class="columns">
+        <div class="column col-12 learn-link">
+          <span class="icn icn-info"></span><a href="/how-it-works">Learn about these results</a>
+        </div>
+      </div>
+      <hr class="hs">
+      <div class="results-pages">
+        <div class="columns">
+          <div class="column col-6 col-md-12">
+            <div class="page-counter">
+              {#- Updated dynamically in JS #}
+            </div>
+          </div>
+          <div class="column col-6 col-md-12">
+            <div class="pagination-box float-right" id="pagination-box">
+              {#- Updated dynamically in JS #}
+            </div>
+          </div>
+        </div>
+      </div>
+      <table class="table table-light table-hover load"  id="policy-docs-result-table"nowrap>
+        <colgroup>
+          <col class="colgroup-accordion-col">
+          <col class="colgroup-xl-col">
+          <col class="colgroup-medium-col">
+          <col class="colgroup-small-col">
+        </colgroup>
+        <thead>
+          <tr>
+            <th></th>
+            <th class="sort" data-sort="title.keyword">Policy Document <span class="icn icn-sort"></th>
+            <th class="sort" data-sort="organisation" data-order="asc" id="active-sort">Organisation <span class="icn icn-sort"></th>
+            <th class="sort" data-sort="year">
+              <div class="table-header">
+                <div class="table-header-text">
+                  Publication of Year
+                </div>
+                <div class="table-header-icon">
+                  <span class="icn icn-sort"></span>
+                </div>
+              </div>
+            </th>
+          </tr>
+          <tr class="progress-row d-none" id="loading-row">
+            <th colspan=7>
+              <progress class="progress" max="100"></progress>
+            </th>
+          </tr>
+        </thead>
+        <tbody id="policy-docs-results-tbody">
+        {% for i in range(0, 10) %}
+          <tr class="load">
+            <td colspan=7></td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      <div class="results-pages">
+        <div class="columns">
+          <div class="column col-6 col-md-12">
+            <div class="page-counter">
+              {#- Updated dynamically in JS #}
+            </div>
+          </div>
+          <div class="column col-6 col-md-12">
+            <div class="pagination-box float-right" id="pagination-box">
+              {#- Updated dynamically in JS #}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <hr class="fs">
+  <div class="container">
+    <div class="columns">
+      <div class="column col-6 col-md-12">
+        <div class="feedback-box">
+          <p class="bold">About these results</p>
+          <p>To learn more about how reach works and how it has generated these results, go to the <a href="/how-it-works">How Reach works</a> page</p>
+        </div>
+      </div>
+      <div class="column col-6 col-md-12">
+        <div class="feedback-box">
+          <p class="bold">Can't find what you're looking for?</p>
+          <p>We are working to continually improve Reach, if it is not working as you expect, there is an error or you have a suggestion, please <a href="mailto:engineering.datalabs@wellcome.ac.uk">send us your feedback</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr class="fs">
+</section>
+{% endblock %}
+
+{% block hide %}
+<div class="hide">
   <div class="container">
     <hr class="hs">
     <div class="columns">
@@ -160,7 +296,7 @@
               </div>
             </th>
           </tr>
-          <tr class="progress-row d-none" id="loading-row">
+          <tr class="progress-row" id="loading-row">
             <th colspan=7>
               <progress class="progress" max="100"></progress>
             </th>
@@ -210,5 +346,5 @@
   </div>
   <hr class="fs">
     {% endif %}
-</section>
+</div>
 {% endblock %}

--- a/web/web/views/api/api_search_citations.py
+++ b/web/web/views/api/api_search_citations.py
@@ -80,7 +80,8 @@ class ApiSearchCitations:
             resp.body = json.dumps({
                 'status': 'success',
                 'data': results,
-                'count': counter
+                'count': counter,
+                'terms': terms
             }, cls=JSONEncoder)
 
 
@@ -89,5 +90,3 @@ class ApiSearchCitations:
                 'status': 'error',
                 'message': 'The request doesn\'t contain any parameters'
             })
-
-

--- a/web/web/views/api/api_search_policies.py
+++ b/web/web/views/api/api_search_policies.py
@@ -59,7 +59,8 @@ class ApiSearchPolicies:
             resp.body = json.dumps({
                 'status': 'success',
                 'data': results,
-                'count': counter
+                'count': counter,
+                'terms': terms
             }, cls=JSONEncoder)
 
         else:
@@ -67,6 +68,3 @@ class ApiSearchPolicies:
                 'status': 'error',
                 'message': 'The request doesn\'t contain any parameters'
             })
-
-
-


### PR DESCRIPTION
# Description

This PR upgrade Reach's Frontend to use the new API relying on PSQL:
 - Templates now returns mock rows on first load
 - No results page is now an html rendered JS template litteral 
 - Upgrade Reach brand to include `alpha` on contact page

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?
Local tests (Relying on prod database's data
make docker-test
