### PR TITLE
Update contact links

### DIFF
--- a/web/web/src/js/citationsTable.js
+++ b/web/web/src/js/citationsTable.js
@@ -93,7 +93,7 @@ function refreshCitations(data, currentState) {
     // Get the parameters from the policy docs search page and use them
     // to query Elasticsearch
 
-    const resultBox = document.getElementById('policy-docs-results');
+    const resultBox = document.getElementById('citations-results');
     const table = document.getElementById('citations-results-tbody');
     // const loadingRow = document.getElementById('loading-row');
     const pages = document.getElementsByClassName('page-item');

--- a/web/web/src/js/templates/no_results.js
+++ b/web/web/src/js/templates/no_results.js
@@ -62,7 +62,7 @@ const getNoResultsTemplate = (term, source) => {
         <div class="column col-6 col-md-12">
           <div class="feedback-box">
             <p class="bold">Can't find what you're looking for?</p>
-            <p>If something doesn’t look quite right, please get in touch with the team at <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk.</a></p>
+            <p>If something doesn’t look quite right, please <a href="/contact">get in touch with the team</a>.</p>
           </div>
         </div>
       <div class="column col-6 hide-md"></div>

--- a/web/web/templates/about.html
+++ b/web/web/templates/about.html
@@ -48,7 +48,7 @@
         </div>
         <div class="column col-4 col-md-12">
           <div class="text-center"><h3 class="category-title">What are the policy sources?</h3></div>
-          <p>We source policy documents from UNICEF, Médecins Sans Frontières (MSF), National Institute of Clinical Excellence (NICE), the World Health Organisation (WHO), the UK government and the UK parliament. The documents include Reports, Health Technology Assessments, guidelines and position papers. If there are any sources you think are missing, please get in touch with the team at <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk</a></p>
+          <p>We source policy documents from UNICEF, Médecins Sans Frontières (MSF), National Institute of Clinical Excellence (NICE), the World Health Organisation (WHO), the UK government and the UK parliament. The documents include Reports, Health Technology Assessments, guidelines and position papers. If there are any sources you think are missing, please <a href="/contact">get in touch with the team</a>.</p>
         </div>
         <div class="column col-4 col-md-12">
           <div class="text-center"><h3 class="category-title">What are the scientific publications?</h3></div>
@@ -68,7 +68,7 @@
           <div class="text-center">
             <img src="/static/images/Icon_About_Accuracy_100px.svg" alt="">
             <h3 class="category-title">Accuracy</h3>
-            <p>Reach is powered by cutting edge machine learning techniques applied by the data scientists in Wellcome Data Labs. Machine learning is not 100% accurate because it is based on probability, but we are constantly working on Reach to improve its accuracy. If something doesn’t look quite right, please get in touch with the team at <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk</a>.</p>
+            <p>Reach is powered by cutting edge machine learning techniques applied by the data scientists in Wellcome Data Labs. Machine learning is not 100% accurate because it is based on probability, but we are constantly working on Reach to improve its accuracy. If something doesn’t look quite right, please <a href="/contact">get in touch with the team</a>.</p>
           </div>
         </div>
         <div class="column col-4 col-md-12">
@@ -89,7 +89,7 @@
          	<h1>About Wellcome Data Labs</h1>
          	<p>Wellcome Data Labs exists to enable responsible, data-driven decision making at Wellcome and in the wider research cuommunity. We build products, support data innovation in health and research, and blend technology social sciences approaches in our work.
          	</p>
-         	<p>We’d love to hear from you. Get in touch via email: <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk</a></p>
+         	<p>We’d love to hear from you. <a href="/contact">Get in touch via email</a>.</p>
         </div>
         <div class="column col-3 hide-md"></div>
       </div>

--- a/web/web/templates/index.html
+++ b/web/web/templates/index.html
@@ -127,7 +127,7 @@
             <hr class="hs">
             <h3>Accuracy</h3>
           </div>
-          <p>Reach is powered by cutting edge machine learning techniques applied by the data scientists in Wellcome Data Labs. Machine learning is not 100% accurate because it is based on probability, but we are constantly working on Reach to improve its accuracy. If something doesn’t look quite right, please get in touch with the team at <a href="mailto:reach@wellcome.ac.uk">reach@wellcome.ac.uk</a>.</p>
+          <p>Reach is powered by cutting edge machine learning techniques applied by the data scientists in Wellcome Data Labs. Machine learning is not 100% accurate because it is based on probability, but we are constantly working on Reach to improve its accuracy. If something doesn’t look quite right, please <a href="/contact">get in touch with the team</a>.</p>
         </div>
         <div class="column col-4 col-md-12">
           <div class="text-center">

--- a/web/web/templates/results/citations.html
+++ b/web/web/templates/results/citations.html
@@ -374,7 +374,7 @@
     <div class="column col-6 col-md-12">
       <div class="feedback-box">
         <p class="bold">Can't find what you're looking for?</p>
-        <p>We are working to continually improve Reach, if it is not working as you expect, there is an error or you have a suggestion, please <a href="mailto:engineering.datalabs@wellcome.ac.uk">send us your feedback</a></p>
+        <p>We are working to continually improve Reach, if it is not working as you expect, there is an error or you have a suggestion, please <a href="/contact">send us your feedback</a></p>
       </div>
     </div>
   </div>

--- a/web/web/templates/results/policy-docs.html
+++ b/web/web/templates/results/policy-docs.html
@@ -339,7 +339,7 @@
       <div class="column col-6 col-md-12">
         <div class="feedback-box">
           <p class="bold">Can't find what you're looking for?</p>
-          <p>We are working to continually improve Reach, if it is not working as you expect, there is an error or you have a suggestion, please <a href="mailto:engineering.datalabs@wellcome.ac.uk">send us your feedback</a></p>
+          <p>We are working to continually improve Reach, if it is not working as you expect, there is an error or you have a suggestion, please <a href="/contact">send us your feedback</a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

-  Use link to contact page instead of email in all contact copies (Fix #533 )

## Type of change

- [x] :sparkles: New feature

# How Has This Been Tested?

Local checks
