### PR TITLE
Fuzzymatcher Output Fix

### DIFF
--- a/pipeline/reach-fuzzy-matcher/fuzzymatcher_task.py
+++ b/pipeline/reach-fuzzy-matcher/fuzzymatcher_task.py
@@ -206,6 +206,10 @@ class FuzzyMatchRefsOperator(object):
 
         with tempfile.NamedTemporaryFile(mode='wb') as output_raw_f:
             with gzip.GzipFile(mode='wb', fileobj=output_raw_f) as output_f:
+                # This probably looks really odd, but we're basically ensuring that if there are no citations,
+                # that we still at least write a blank string to the start of the file so that
+                # the pipeline doesn't freak out on openining an empty GZip file
+                output_f.write(b' ')
                 for reference in references.values():
                     output_f.write(json.dumps(reference).encode('utf-8'))
                     output_f.write(b'\n')


### PR DESCRIPTION
# Description

Fixes an issue when there are no citations to write resulting in an empty gzip file being pushed down the chain breaking other pipeline tasks

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [ ] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can run the tests. Please also list any relevant details for your test configuration:

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
