### PR TITLE
REDO End to end evaluation pipeline tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ WEB_ECR_ARN := 160358319781.dkr.ecr.eu-west-1.amazonaws.com
 VERSION := build-$(shell date +%Y%m%dT%H%M%SZ)
 LATEST_TAG := latest
 
+
 .PHONY: aws-docker-login
 aws-docker-login:
 	aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin 160358319781.dkr.ecr.eu-west-1.amazonaws.com
-
 
 # _____________
 # TODO:

--- a/base/hooks/s3hook.py
+++ b/base/hooks/s3hook.py
@@ -19,6 +19,7 @@ ORGS = [
     'unicef',
     'parliament',
     'acme',
+    'evaluation',
 ]
 
 

--- a/pipeline/reach-evaluator/Dockerfile
+++ b/pipeline/reach-evaluator/Dockerfile
@@ -1,0 +1,16 @@
+FROM reach.base
+
+WORKDIR /opt/reach
+
+COPY ./requirements.txt /opt/reach/requirements.evaluator.txt
+
+RUN pip install -U pip && \
+        python3 -m pip install -r /opt/reach/requirements.evaluator.txt
+
+
+COPY ./evaluator_task.py /opt/reach/evaluator_task.py
+
+# Give execution rights to the entrypoint Python script
+RUN chmod +x /opt/reach/evaluator_task.py
+
+ENTRYPOINT ["/opt/reach/evaluator_task.py"]

--- a/pipeline/reach-evaluator/evaluator_task.py
+++ b/pipeline/reach-evaluator/evaluator_task.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+Operators for running the end-to-end evaluation of Reach.
+"""
+import os
+import tempfile
+import logging
+import json
+import gzip
+import argparse
+from datetime import date
+
+from hooks import s3hook
+from hooks.sentry import report_exception
+
+# from airflow.models import BaseOperator
+# from airflow.utils.decorators import apply_defaults
+
+from reach_evaluator import ReachEvaluator
+
+logger = logging.getLogger(__name__)
+
+def _yield_jsonl_from_gzip(fileobj):
+    """ Yield a list of dicts read from gzipped json(l)
+    """
+    with gzip.GzipFile(mode='rb', fileobj=fileobj) as f:
+        for line in f:
+            yield json.loads(line)
+
+def _yield_jsonl(fileobj):
+    """ Yield a list of dicts read from gzipped json(l)
+    """
+    for line in fileobj:
+        yield json.loads(line)
+
+def _get_span_text(text, span):
+    """Get the text that is demarcated by a span in a prodigy dict
+    """
+    return text[span['start']:span['end']]
+
+def _write_json_gz_to_s3(s3, data, key):
+    """Write a list of jsons to json.gz on s3
+    """
+    with tempfile.NamedTemporaryFile(mode='wb') as output_raw_f:
+        with gzip.GzipFile(mode='wb', fileobj=output_raw_f) as output_f:
+            for item in data:
+                output_f.write(json.dumps(item).encode('utf-8'))
+                output_f.write(b'\n')
+
+        output_raw_f.flush()
+        s3.load_file(
+            filename=output_raw_f.name,
+            dst_key=key
+        )
+
+def _read_json_gz_from_s3(s3, key):
+    """Write a list of jsons to json.gz on s3
+    """
+    with tempfile.TemporaryFile(mode='rb+') as tf:
+        key = s3.get_s3_object(key)
+        key.download_fileobj(tf)
+        tf.seek(0)
+
+        return list(_yield_jsonl_from_gzip(tf))
+
+def _read_jsonl_from_s3(s3, key):
+    """Write a list of jsons to json.gz on s3
+    """
+    with tempfile.TemporaryFile(mode='rb+') as tf:
+        key = s3.get_s3_object(key)
+        key.download_fileobj(tf)
+        tf.seek(0)
+
+        return list(_yield_jsonl(tf))
+
+class EvaluateOperator(object):
+    """
+    Take the output of fuzz-matched-refs operator and evaluates the results
+    against a manually labelled gold dataset, returning results in a json
+    to s3.
+
+    Args:
+        src_s3_key: S3 URL for input
+        dst_s3_key: S3 URL for output
+    """
+
+    template_fields = (
+        'gold_s3_key',
+        'reach_s3_key',
+        'dst_s3_key',
+    )
+
+    def __init__(self, gold_s3_key, reach_s3_key, dst_s3_key, reach_params=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.gold_s3_key = gold_s3_key
+        self.reach_s3_key = reach_s3_key
+        self.dst_s3_key = dst_s3_key
+        self.reach_params = reach_params
+
+    @report_exception
+    def execute(self):
+
+        s3 = s3hook.S3Hook()
+
+        results = []
+
+        # Read data from S3
+        gold = _read_jsonl_from_s3(s3, self.gold_s3_key)
+        reach = _read_json_gz_from_s3(s3, self.reach_s3_key)
+
+        evaluator = ReachEvaluator(gold, reach)
+        eval_results = evaluator.eval()
+
+        # Add additional metadata
+
+        eval_results['gold_refs'] = self.gold_s3_key
+        eval_results['reach_refs'] = self.reach_s3_key
+        eval_results['reach_params'] = self.reach_params
+
+        # Write the results to S3 with today's datestamp
+        today = date.today()
+        # 'folder/folder2/evaluator.json.gz'
+        split_path = os.path.split(self.dst_s3_key)
+        file_name = split_path[1] # 'evaluator.json.gz''
+        index_of_dot = file_name.index('.') # first dot index
+        key_with_date = os.path.join(
+            split_path[0],
+            file_name[:index_of_dot]+'_'+str(today)+file_name[index_of_dot:]
+            )
+        # 'folder/folder2/evaluator_2020-05-18.json.gz'
+        _write_json_gz_to_s3(s3, [eval_results], key=key_with_date)
+
+        logger.info(
+            'EvaluateOperator: Finished Evaluating Reach matches'
+        )
+
+
+if __name__ == '__main__':
+
+    arg_parser = argparse.ArgumentParser(
+        description='Evaluates how well the algorithm has performed given some'
+                    ' gold standard data and writes the'
+                    ' results to the given S3 path.'
+    )
+    arg_parser.add_argument(
+        'gold_s3_key',
+        help='The gold annotation path in s3.'
+    )
+    arg_parser.add_argument(
+        'src_s3_key',
+        help='The source path to s3.'
+    )
+    arg_parser.add_argument(
+        'dst_s3_key',
+        help='The destination path to s3.'
+    )
+    
+    args = arg_parser.parse_args()
+
+    evaluateRefs = EvaluateOperator(
+        gold_s3_key=args.gold_s3_key,
+        reach_s3_key=args.src_s3_key,
+        dst_s3_key=args.dst_s3_key,
+        )
+    evaluateRefs.execute()
+

--- a/pipeline/reach-evaluator/requirements.txt
+++ b/pipeline/reach-evaluator/requirements.txt
@@ -1,0 +1,1 @@
+https://datalabs-public.s3.eu-west-2.amazonaws.com/reach_evaluator/reach_evaluator-2020.1.1-py3-none-any.whl


### PR DESCRIPTION
**Something horrible happened in the previous PR so this is a redo of https://github.com/wellcometrust/reach/pull/516**

There is now scraper data for an organisation called 'evaluation'. So this would be the starting point for the evaluation flow, which would look like:
```
ORG = evaluation
make run-parser
make run-extracter
make run-indexer-fulltexts
make run-indexer-epmc
make run-fuzzymatcher
make run-evaluator
```
Not sure how the argo flow would actually be coded though! But this is how it would work running locally).

# Questions

- These changes work and give reasonable output files when I run things locally, but I worry I haven't edited other files which will allow them to be run in production. Can you comment on that?

# Description

Incorporating the end to end evaluation - https://github.com/wellcometrust/reach/issues/315.
The old method was written for airflow, so it'll be adapted for the new architecture.

This involves a new tasks which is only to be run when org=evaluation:
1. evaluator_task.py - uses the fuzzy match results and the gold standard data to evaluate the quality of reach's results

## Type of change

Please delete options that are not relevant.

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [x] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

Running `make run-evaluator` when org=who_iris worked and created the output file:
s3://datalabs-dev/evaluator/evaluator_2020-05-22.json.gz

Ideally I would test running `make run-evaluator` when org=evaluation but I don't have the fuzzymatch file for the evaluation organisation yet (since I can't run the ES tasks lcoally)

# Results
These were from when I combined all the fuzzymatch results together and ran the evaluation task on them. This method wouldnt be done in practice, but I couldn't run the fuzzymatch task just on the extracted references from the evaluation 'org' since I dont have the ES credentials.

Using `s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_gold_matched_references_snake.jsonl`
```
{"doc_metrics": {"found": 7, "missed": 4, "accuracy": 0.64, "total": 11},

"ref_metrics": {"possible": 85, "actual": 107, "found": 37, "missed": 48,
"spurious": 70, "recall": 0.44, "precision": 0.35, "f1": 0.39},

"found_docs_ref_metrics": {"possible": 74, "actual": 107, "found": 37,
"missed": 37, "spurious": 70, "recall": 0.5, "precision": 0.35, "f1": 0.41},

"gold_refs": "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8_gold_matched_references_snake.jsonl", 

"reach_refs": "s3://datalabs-dev/combinedmatches/combinedmatches.json.gz", "reach_params": null}
```
Using `s3://datalabs-data/reach_evaluation/data/sync/2019.10.8-fuzzy-matched-gold-refs-manually-verified.jsonl`
```
{
"doc_metrics": {"found": 4, "missed": 2, "accuracy": 0.67, "total": 6},

"ref_metrics": {"possible": 37, "actual": 46, "found": 28, "missed": 9,
"spurious": 18, "recall": 0.76, "precision": 0.61, "f1": 0.67}, 

"found_docs_ref_metrics": {"possible": 33, "actual": 46, "found": 28,
"missed": 5, "spurious": 18, "recall": 0.85, "precision": 0.61, "f1": 0.71}, 

"gold_refs": "s3://datalabs-data/reach_evaluation/data/sync/2019.10.8-fuzzy-matched-gold-refs-manually-verified.jsonl", 

"reach_refs": "s3://datalabs-dev/combinedmatches/combinedmatches.json.gz", 

"reach_params": null}
```

and a reminder about what these mean:
1) doc_metrics - Evaluate success of reach in finding docs in the gold set.
2) ref_metrics - Precision/Recall/F1 for all references in the gold set.
3) found_docs_ref_metrics - Precision/Recall/F1 for only these references from the gold set which are present in documents that were found by reach.

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
