### PR TITLE
Bumping deep_reference_parser version

### DIFF
--- a/pipeline/reach-es-extractor/requirements.txt
+++ b/pipeline/reach-es-extractor/requirements.txt
@@ -3,4 +3,4 @@ numpy
 pandas
 scikit-learn
 sentry-sdk
-https://github.com/wellcometrust/deep_reference_parser/releases/download/2020.4.29/deep_reference_parser-2020.4.5-py3-none-any.whl
+https://github.com/wellcometrust/deep_reference_parser/releases/download/2020.4.29/deep_reference_parser-2020.8.5-py3-none-any.whl


### PR DESCRIPTION
# Description

Bumps the version being loaded for deep_reference_parser in the reach-es-extractor task.

## Type of change

Please delete options that are not relevant.

- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [ ] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can run the tests. Please also list any relevant details for your test configuration:

# Checklist:

- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`
